### PR TITLE
Add location server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ You may need to browse to this port, even if you are accessing in development on
 
 `http://localhost:8080/api` should give you yor followers!
 
+### `server/location/`
+
+`/api` now responds with a location object as part of its JSON reponse, which minimally includes at least one form of location (likely, twitter location (`twitterString` or postcode (`pc`/ `pc7`/ `pc8`/ `pcd`) & `latLong`), and a specificity of that location, which will only be reported if meaningful (ie blank/ incomprehensible locations are not counted in specificity)
+
+##### location.specificity
+* 0 - no location
+* 1 - region / country
+* 3 - Local Authority
+* 5 - pcd (postcode district, eg `WC2A` or `NN6`)
+* 6 - parliamentary_constituency
+* 10 - pc7/ pc8 (eg `WC2A1AA` / `WC2A 1AA`) or latLong
+
+##### passing location data
+Calls to the `/api` route establish a `location` object as a property of express-session's `session` passed back and forth on request/ response on the domain.
+The primary means of passing a detailed location to the server is via query params `pc` (postcode) or `latlong`. Acceptance is liberal, but 7-digit, no-space postcodes and leaflet.js latLng (`{lat,lng}`) are standard. Where lat, lng are not explicit, order is lng, lat.
+
 ### Data
 
 The server can work with data stored in memory, in Redis, or in MongoDB.

--- a/matcher.js
+++ b/matcher.js
@@ -1,0 +1,47 @@
+const csvParse = require('csv-parser');
+const fs = require('fs');
+
+const redis = require('redis'),
+  client = redis.createClient();
+
+const { newRedisServer, redisPort, waitingForRedisServer, shutdownRedis } = require ('./newredisserver'),
+  redisServer = newRedisServer();
+
+// if you'd like to select database 3, instead of 0 (default), call
+// client.select(3, function() { /* ... */ });
+
+const inputCsvFiles = ['./PeoplesMomentum_followers.csv']
+
+
+client.on("error", err=> {
+    console.log(`Error ${err}`);
+});
+
+const testConnectionSync = ()=> {
+  client.set("string key", "string val", redis.print);
+  client.hset("hash key", "hashtest 1", "some value", redis.print);
+  client.hset(["hash key", "hashtest 2", "some other value"], redis.print);
+  client.hkeys("hash key", function (err, replies) {
+      console.log(replies.length + " replies:");
+      replies.forEach(function (reply, i) {
+          console.log("    " + i + ": " + reply);
+      });
+      client.quit();
+  });
+};
+
+const loadStaticData = (inputCsvFiles)=> {
+  const comparatorSets = inputCsvFiles
+    .map (file => {
+      dataset = new Promise ((res,rej) => {
+        fs.createReadStream('data.csv')
+          .pipe(csvParse())
+          .on('data', (data) => results.push(data))
+          .on('end', () => {
+            res (results)
+            console.log(results);
+          });
+      });
+    });
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,46 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+    },
+    "@hapi/joi": {
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+      "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+      "requires": {
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -46,9 +86,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "ajv": {
@@ -223,6 +263,22 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -307,9 +363,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -334,12 +390,14 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -401,6 +459,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
       "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -599,9 +681,9 @@
       }
     },
     "connect-redis": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-4.0.2.tgz",
-      "integrity": "sha512-SuOGp/2dgpH738SYj0rZfoeKpuV/C4W0APGWrvyC3ijgXkKq/LKdgyCfW2oSxIPE1ndeOgmuei2bh3wIU50ZLw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-4.0.3.tgz",
+      "integrity": "sha512-Php0P0ShNfilW6f2d/2v7Q0VAiFeBYsg0bIgu8ST3x26CcQ1JtzV6vxPLUwK0uiq10hQSMR+HzSNhWbcvx6nLg=="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -687,6 +769,19 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "csv-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.1.tgz",
+      "integrity": "sha512-/u51FlBo75BcY/IL0WGibT628rr/xn4cXS9jX+AwT4x9yE7kqGqss7YgXpbdFai6m3uNbr4g1F19BoXBFeiJbA==",
+      "requires": {
+        "@hapi/joi": "^16.1.4",
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^1.0.0",
+        "generate-object-property": "^1.0.0",
+        "minimist": "^1.2.0",
+        "ndjson": "^1.4.0"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -701,6 +796,13 @@
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "debug-log": {
@@ -881,6 +983,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -891,9 +1001,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -904,8 +1014,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       },
       "dependencies": {
         "object-keys": {
@@ -926,6 +1036,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1071,13 +1186,15 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -1098,13 +1215,15 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -1152,6 +1271,14 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "doctrine": {
@@ -1163,18 +1290,6 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -1257,12 +1372,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -1272,13 +1387,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -1336,6 +1451,14 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
       }
     },
     "expand-brackets": {
@@ -1360,6 +1483,14 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "define-property": {
@@ -1379,12 +1510,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -1436,12 +1561,14 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1471,17 +1598,19 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "safe-buffer": {
           "version": "5.2.0",
@@ -1613,6 +1742,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fetch-ponyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.0.tgz",
+      "integrity": "sha512-bLc7JCjpJZZUXVxbgwUhd72Q19MAokrCXOg/Akq+wl0uFLFLklFdBkZo5OpQ3kLI0oGqrKdx6t5Zo3QwXBRmbQ==",
+      "requires": {
+        "node-fetch": "~2.6.0"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1674,12 +1811,14 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1714,6 +1853,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1794,8 +1956,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1816,14 +1977,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1838,20 +1997,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1968,8 +2124,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1981,7 +2136,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1996,7 +2150,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2004,14 +2157,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2030,7 +2181,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2111,8 +2261,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2124,7 +2273,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2210,8 +2358,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2247,7 +2394,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2267,7 +2413,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2311,14 +2456,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2334,6 +2477,14 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -2341,10 +2492,12 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -2361,9 +2514,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2427,12 +2580,20 @@
         "timed-out": "^4.0.0",
         "unzip-response": "^2.0.1",
         "url-parse-lax": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "har-schema": {
@@ -2503,9 +2664,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "http-errors": {
@@ -2558,6 +2719,14 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "import-lazy": {
@@ -2835,6 +3004,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -2883,9 +3057,9 @@
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2924,6 +3098,17 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-client": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/json-client/-/json-client-0.9.3.tgz",
+      "integrity": "sha512-HCsXte+OeU9m/zaTk8oIBN1Mib2uBSIFMc4jGjLn89BeKJ4KMP9C+2keDvWAv95fqT5/vgkIhHJdWWGN+PRQUQ==",
+      "requires": {
+        "es6-object-assign": "^1.1.0",
+        "fetch-ponyfill": "^6.0.2",
+        "qs": "^6.5.2",
+        "url": "^0.11.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2969,9 +3154,9 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -3061,6 +3246,14 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "make-dir": {
@@ -3165,38 +3358,23 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.0.0.tgz",
-      "integrity": "sha512-FKNU4XrAPDX0+ynwns7njVu4RolyG1mUKSlT6n6GwGXLtYSYh2Znc0S83Rl6zEr1zgFfXvAzIBabnmItm+n19g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
       "requires": {
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "minizlib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.0.0.tgz",
-      "integrity": "sha512-8f6fgftVu7S2bYKe4Ks9jS5ViU/3As9kEmCg6p9T5OCDAzxVooUmhhSqGar19ZR07xh0rknj9ZmGme0bv0d+Nw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "mixin-deep": {
@@ -3264,12 +3442,14 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -3316,6 +3496,27 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "neat-csv": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/neat-csv/-/neat-csv-5.1.0.tgz",
+      "integrity": "sha512-P5rOGmHN6P/h0ZxEnVUhSuOMcyv2X95Q+dQxMEvqg+Qb0tw8VmHuhQmNFNv1xjD4+OCD1oWKN5rC022gGULXcA==",
+      "requires": {
+        "csv-parser": "^2.3.0",
+        "get-stream": "^5.1.0",
+        "to-readable-stream": "^2.1.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -3326,6 +3527,30 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-postcodes.io": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-postcodes.io/-/node-postcodes.io-1.0.0.tgz",
+      "integrity": "sha512-UaF4I8X1uhj7SIPfhaPTzr5qir17fkOlTkfQWCEcuY0eyb65MZ8iIXnE0LjlnDrKIB4TICt2M8jz305W1fI43g==",
+      "requires": {
+        "axios": "^0.18.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "nodemon": {
       "version": "1.19.4",
@@ -3491,15 +3716,15 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "object.pick": {
@@ -3540,7 +3765,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3824,6 +4048,20 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcode": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/postcode/-/postcode-0.2.5.tgz",
+      "integrity": "sha1-HBiTp7baLqXI8Zv/FYWTrIFQLHg="
+    },
+    "postcodesio-client": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/postcodesio-client/-/postcodesio-client-0.3.4.tgz",
+      "integrity": "sha512-ozvCCyMeNPJJyA4wJn1W5bQoAz4beJH55zEsdwJD/DPfHys8zaHxoR6ccEHcO5sa7CrtHmg2yCl+SsAonDzjog==",
+      "requires": {
+        "json-client": "^0.9.2",
+        "postcode": "^0.2.5"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3839,8 +4077,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -3890,6 +4127,15 @@
       "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3899,6 +4145,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -3934,9 +4185,9 @@
       }
     },
     "react-is": {
-      "version": "16.10.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
-      "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
       "dev": true
     },
     "read-pkg": {
@@ -3964,7 +4215,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3973,14 +4223,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
       }
     },
     "readdirp": {
@@ -4116,13 +4358,6 @@
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-        }
       }
     },
     "resolve": {
@@ -4135,10 +4370,9 @@
       }
     },
     "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -4373,6 +4607,14 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "define-property": {
@@ -4392,12 +4634,6 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -4547,6 +4783,14 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4658,7 +4902,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4740,23 +4983,16 @@
       }
     },
     "tar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.2.tgz",
-      "integrity": "sha512-s6QnhHIoyEPImp1Y4Tq3UOhPMT6/4kgHwzeZc9fbgq0/+s6RAzezIT43Meepn5RdUFpxdzQkd5x2PkcFdVIEPw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+      "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
       "requires": {
         "chownr": "^1.1.3",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
-        "minizlib": "^2.0.0",
+        "minizlib": "^2.1.0",
         "mkdirp": "^0.5.0",
         "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "term-size": {
@@ -4779,6 +5015,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
     },
     "timed-out": {
       "version": "4.0.1",
@@ -4814,6 +5059,11 @@
           }
         }
       }
+    },
+    "to-readable-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w=="
     },
     "to-regex": {
       "version": "3.0.2",
@@ -4944,13 +5194,15 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -5023,12 +5275,6 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
         }
       }
     },
@@ -5076,6 +5322,22 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -5094,8 +5356,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-inspect": {
       "version": "0.1.8",
@@ -5109,6 +5370,13 @@
         "isarray": "0.0.1",
         "json3": "3.3.0",
         "object-keys": "0.5.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
       }
     },
     "utils-merge": {
@@ -5179,8 +5447,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -5211,14 +5478,12 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server",
-    "dev": "nodemon -w server server",
+    "dev": "nodemon server",
     "matcher": "node matcher.js",
     "lint": "standard --fix \"server/**/*.js\" \"bin/**/*.js\"",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -24,7 +24,9 @@
     "lodash": "^4.17.15",
     "mongodb": "^3.3.3",
     "morgan": "^1.9.1",
+    "node-postcodes.io": "^1.0.0",
     "oauth": "^0.9.15",
+    "postcodesio-client": "^0.3.4",
     "redis": "^2.8.0",
     "redis-server": "^1.2.2",
     "request": "^2.88.0",

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,8 @@ const oauth = require('./oauth')
 const twitter = require('./twitter')
 const matcher = require('./matcher')
 const sessionStore = require('./sessionStore')
+const { LocationObject, populateLocationObject, constituencyFromPostcode } = require('./location')
+const { promiseyLog } = require ('./location/helpers');
 
 const app = express()
 app.use(logger('tiny', { stream: { write: msg => debug(msg.trim()) } }))
@@ -24,6 +26,7 @@ app.use(cors({
 }))
 
 const PORT = process.env.PORT || 8080
+let usingReact = true;
 
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use(bodyParser.json())
@@ -68,11 +71,13 @@ app.get('/sessions/callback', async (req, res) => {
 
     res.redirect(req.session.origin)
   } catch (e) {
+    console.log(e);
     res.status(500).send(e.message)
   }
 })
 
 app.get('/', async (req, res) => {
+console.log('Request was to /');
   const { userData } = req.session
   if (!userData) {
     return res.redirect('/login')
@@ -84,24 +89,103 @@ app.get('/test', (req, res) => {
   res.redirect('/api')
 })
 
+
+// In frontend, location may be a string/ empty string, or a LocationObject containing fields including
+// twitterString : a string/ empty string
+// (test for location known with: if (location || location.twitterString) ... )
+// Better is to test for location specificity
+// location.specficity = 0 => no location
+// location.specficity = 10 => full postcode or lat/long
+// But test, eg: if (!location || location < x) ... since string.prop = undefined and (undefined < x) == false
 app.get('/api', async (req, res) => {
   const { userData, oauthAccessToken, oauthAccessTokenSecret } = req.session
   if (!userData) {
+    console.log('No userData in session - sending 403');
     return res.status(403).send('You are not logged in with Twitter')
   }
   try {
     const followerIds = await twitter.getFollowerIds(userData.screen_name, oauthAccessToken, oauthAccessTokenSecret)
     const matchedIds = await matcher(followerIds)
-    res.send({ total: followerIds.length, matched: matchedIds.length })
+console.log('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> query:',req.query);
+    let location = [
+      req.query,                         // query: We assume any query passed will include one+ of pc, p7, pc8, latlong
+      req.session.location,              // session: NB Any location object from session may be partial
+      userData.location,                 // userData: is the twitterString, ie location as it appears on user's Twitter profile
+      LocationObject()
+    ];
+    // console.log(location);
+    req.session.location = await populateLocationObject (location, locationOptions={ useGoogle : true} ) ;
+    res.send({ total: followerIds.length, matched: matchedIds.length, location: req.session.location })
   } catch (e) {
+    console.log(e);
     res.status(e.statusCode || 500).send(e.message)
   }
 })
 
+
+// NB For future cleverness with userData.geo_enabled: geo_enabled is deprecated and will always be null. Still available via GET account/settings. This field must be true for the current user to attach geographic data when using POST statuses / update
+app.get('/locationtest', async (req, res) => {
+  const { userData, oauthAccessToken, oauthAccessTokenSecret } = req.session
+  let followerIds = [], matchedIds = [];
+  console.log('Got route /locationtest');
+console.log(req.query);
+  let location = [
+    req.query,                         // query: We assume any query passed will include one+ of pc, p7, pc8, latlong
+    req.session.location
+  ];
+  if (userData) {
+    followerIds = await twitter.getFollowerIds(userData.screen_name, oauthAccessToken, oauthAccessTokenSecret);
+    matchedIds = await matcher(followerIds);
+    location.push (userData.location);
+  }
+  location.push (LocationObject());
+
+  try {
+      req.session.location = await populateLocationObject (location, { useGoogle : true} ) ;
+    } catch (e) {
+      console.log(e);
+      res.status(e.statusCode || 500).send(e.message)
+    }
+
+  // set usingReact to false for express routing (ie, not React):
+  if (usingReact) {
+    // normal usage - pass
+    res.send({ total: followerIds.length, matched: matchedIds.length, location: req.session.location })
+  } else {
+    if (req.session.location.specificity < 2)
+      res.redirect(200, '/your_location_helps');
+    if (req.session.location.specificity < 5)
+      res.redirect(200, '/location_map');
+  }
+})
+
+app.get('/location_lookup', async (req, res) => {
+  const data = constituencyFromPostcode(req.query.pc7)
+    // .then(promiseyLog('before second process:'))
+    .then (data => {
+      if (data.error)
+        return { error : data.error }
+      return data
+    })
+    // .then(promiseyLog('response:'))
+    .then (result => {
+    res.status(200).send(result)
+  });
+})
+
+app.get('/your_location_helps', async (req, res) => {
+  res.status(500).send('Not implemented')
+})
+
+app.get('/location_map', async (req, res) => {
+  res.status(500).send('Not implemented')
+})
+
 app.get('*', function (req, res) {
+  console.log(`${req.url} redirecting to /`);
   res.redirect('/')
 })
 
 app.listen(PORT, function () {
-  debug('App running on port ' + PORT + '!')
+  debug('API server listening on port ' + PORT + '!')
 })

--- a/server/location/README.md
+++ b/server/location/README.md
@@ -1,0 +1,17 @@
+### location modules
+
+ The plan is to compare a users's location, as entered via Location API, on a form, or from Twitter location, with a list of marginals they can help with outreach in, to point them towards the most useful nearby sessions.
+
+ Currently, each postcode is done via a postcodes.io lookup.
+ Which data are retrieved and stored from postcodes.io can be changed in `requests.js`.
+ Either of `postcodesio-client` or `node-postcodes.io` wrapper libraries can be used but `node-postcodes.io` and fucntionality will styart diverging soon. Currently the difference between libraries is transparent to `location/index.js` from `requests.js`.
+
+ Next I will build in pluggability mto actually compare the locations we have to a list of target seats.
+
+ The intention is next to build in a static postcode file as in the GSS-code converter.
+ Then To use Google's API to match input better than just requiring lat/long or full postcode.
+ Then to nudge users to provide a location if they didn't.
+ Then to ask users to click a map for a more detailed location if the location we have is not specific.
+ Eventually the plan is to match multiple results, such as partial or fuzzy locations, against multiple locations (ie reachable canvassing sessions) within constituencies.
+
+ 

--- a/server/location/helpers.js
+++ b/server/location/helpers.js
@@ -1,0 +1,151 @@
+const endsWithPostcodeRE = new RegExp(/([a-z|A-Z]{1,2}\d(\d|\w)?)\s?(\d[a-z|A-Z]{2})?\s*$/,'m');
+const pc7Regexp = new RegExp(/([a-z|A-Z]{1,2}\d(\d|\w)?)(\d[a-z|A-Z]{2})/);
+const pc8Regexp = new RegExp(/([a-z|A-Z]{1,2}\d(\d|\w)?) (\d[a-z|A-Z]{2})/);
+const pcdRegexp = new RegExp(/([a-z|A-Z]{1,2}\d(\d|\w)?)\s*$/);
+const latLongEastWestRegExp = new RegExp(/(.*)([NSns])(.*)([EWew])(.*)/);
+const latLongDigitsRegExp = new RegExp(/^\s*\(?\s*(-?\d*.\d*)\s*,\s*(-?\d*.\d*)\s*\)?\s*$/);
+const is4dplatLongRegExp = new RegExp(/^(-?\d*(.\d{0,4})?),(-?\d*(.\d{0,4})?)$/);
+const whitespaceRegExp = new RegExp(/(^\s+|\s+$)/g);
+
+// match pc7, pc8, pcd
+const isPc7 = pc => pc && !!(pc.match(pc7Regexp))
+const isPc8 = pc => pc && !!(pc.match(pc8Regexp))
+const isPostcodeDistrict = pc => (typeof pc === 'string') && !!(pc.match(pcdRegexp))
+
+const isFullPostcode = pc => (typeof pc === 'string') && (isPc7(pc) || isPc8(pc));
+const isPostcode = pc => isFullPostcode(pc) || isPostcodeDistrict(pc);
+
+const endsWithPostcode = pc => (pc && pc.match(endsWithPostcodeRE))
+
+// retrieve pc7, pc8, pcd
+
+const partsFromPostcode = pc => {
+  pc = pc.toUpperCase();
+  const match7 = pc.match(pc7Regexp);
+  const match8 = pc.match(pc8Regexp);
+  if (match7)
+    return [match7[1], match7[2]]
+  if (match8)
+    return [match8[1], match8[2]]
+  if (isPostcodeDistrict(pc))
+    return [pc.match(pcdRegexp)[1], null]
+}
+
+const pc7FromFullPostcode = pc => {
+  const [pcd, inwardCode] = partsFromPostcode(pc);
+  return `${pcd}${inwardCode}`.toUpperCase();
+}
+const pc8FromFullPostcode = pc => {
+  const [pcd, inwardCode] = partsFromPostcode(pc);
+  return `${pcd} ${inwardCode}`.toUpperCase();
+}
+const districtFromFullPostcode = pc => {
+  const [pcd, inwardCode] = partsFromPostcode(pc);
+  return `${pcd}`.toUpperCase();
+}
+const districtFromPostcodeDistrict = pc => {
+  const [pcd] = partsFromPostcode(pc);
+  return `${pcd}`.toUpperCase();
+}
+const postcodeFromString = pc => {
+  if (!pc)
+    return null;
+  const [_, pcd, inwardCode] = pc.match(endsWithPostcodeRE);
+  return (`${ pcd }${ inwardCode? ' '+inwardCode : '' }`).toUpperCase();
+}
+
+const isLeafletLatLng = latLng =>
+  (typeof latLng === 'object') && (typeof latLng.lat === 'number') && (typeof latLng.lng === 'number')
+
+const toLatLong = latLong => {
+  if (!latLong)
+    return null
+  if (Array.isArray(latLong) && latLong.length===2 && typeof (latLong[0])==='number' && typeof (latLong[1])==='number')
+    return ({ lat : latLong[0],  lng : latLong[0] })
+  if (typeof latLong==='object')
+    return (latLong.lat===undefined || latLong.lng===undefined) ?
+      null
+      : latLong
+if (typeof latLong==='string')
+console.log('##',latLong);
+console.log('###',latLongFromString(latLong));
+  if (typeof latLong==='string')
+    return latLongFromString(latLong)
+  return null
+}
+
+const toStandardLatLong = latLong => {
+  const result = toLatLong(latLong);
+  if (!result || result.lat===undefined || result.lng===undefined)
+    return null
+  console.log(result,{lat : roundToNearest(0.001)(result.lat),lng : roundToNearest(0.001)(result.lng)});
+  return {
+      lat : roundToNearest(0.001)(result.lat),       // 110 metre precision
+      lng : roundToNearest(0.001)(result.lng)
+    }
+}
+
+
+//NB lat,long in strings and arrays is ordered as lng, lat- ie W/E, N/S or X,Y - this is what Google maps uses.
+const latLongFromString = latLong => {
+  latLong = latLong.replace(whitespaceRegExp, '')
+  if (!latLong)
+    return null;
+  const eastWest = latLong.match(latLongEastWestRegExp);
+  if (eastWest)
+    latLong = `${eastWest[1]}${eastWest[3]}${eastWest[5]}`;
+  const matchDigits = latLong.match(latLongDigitsRegExp);
+  if (!matchDigits)
+    return null;
+  let [_, lng, lat] = matchDigits;
+console.log('Found something:',lat,lng);
+  lat = 1*lat;
+  lng = 1*lng;
+  if (eastWest) {
+    if (eastWest[2]==="S" || eastWest[2]==="s")
+      lat= -lat;
+    if (eastWest[4]==="W" || eastWest[4]==="w")
+      lng= -lng;
+  }
+  return { lat, lng }
+}
+
+const latLongFrom4dpLatLongString = latLong => {
+  if (!latLong)
+    return null;
+  const groups = latLong.match(is4dplatLongRegExp);
+  if (!groups)
+    return null;
+  const [, lng, , lat] = groups;
+  return { lng, lat }
+}
+
+const latLongIsInBritishIsles = ({lat, lng}) => (
+  lat < 2.28
+  && 0.75*lat - 0.25*lng> 37.9
+  && 7.25*lat - 2.25*lng > 366.6
+  && 14.25*lat + 6.25*lng > 659.5
+  && -22.75*lat + 8.25*lng > 1395.3
+  && lat>-8.9   // Northern Ireland
+  // && lat>-10.4  // Ireland
+)
+
+
+const roundToNearest = unit => num =>
+  Math.floor (0.5+ (num*unit)) / unit
+
+
+const promiseyLog = message => result =>  {
+  if (message)
+    console.log(message);
+  console.log(result);
+  return result
+}
+
+
+module.exports = { isPc7, isPc8, isPostcodeDistrict, isFullPostcode, isPostcode, endsWithPostcode,
+  pc7FromFullPostcode, pc8FromFullPostcode, districtFromFullPostcode, districtFromPostcodeDistrict,
+  postcodeFromString,
+  toStandardLatLong, toLatLong, isLeafletLatLng, latLongFromString, latLongFrom4dpLatLongString,
+  roundToNearest, latLongIsInBritishIsles, promiseyLog
+}

--- a/server/location/helpers.test.js
+++ b/server/location/helpers.test.js
@@ -1,0 +1,67 @@
+const { isPc7, isPc8, isPostcodeDistrict, isFullPostcode, isPostcode, endsWithPostcode,
+  pc7FromFullPostcode, pc8FromFullPostcode, districtFromFullPostcode, districtFromPostcodeDistrict,
+  postcodeFromString,
+  toStandardLatLong, toLatLong, isLeafletLatLng, latLongFromString, latLongFrom4dpLatLongString,
+  roundToNearest, latLongIsInBritishIsles, promiseyLog
+} = require('./helpers');
+
+const test = (fn, input, expected, message, logLevel=1) => {
+  const actual = fn(input);
+  // const result = (Boolean(actual) == expected);
+  const result = (actual) == expected);
+  let output = '';
+  let formattedInput = (typeof input === 'object') ?
+    input
+    : input.toString()
+  if (logLevel || !result)
+    output += `${fn.name}(${formattedInput})`;
+  if (logLevel > 1)
+    output += `: ${actual}`
+  if (result) {
+    if (logLevel)
+      output += ` OK`
+    } else {
+      output += `${message || ''} - expected ${expected} but actual ${actual}`;
+    }
+  if (logLevel)
+    console.log(output);
+  return result;
+
+}
+
+test (isPc7, 'SW1A 0AA', false);
+test (isPc7, 'SW1A0AA', true);
+test (isPc8, 'SW1A 0AA', true);
+test (isPc8, 'SW1A0AA', false);
+test (isPc7, 'E2 0AA', false);
+test (isPc7, 'E20AA', true);
+test (isPc8, 'E2 0AA', true);
+test (isPc8, 'E20AA', false);
+test (isPc7, 'E201AA', true);
+test (isPc8, 'E201AA', false);
+test (isPostcodeDistrict, 'SW1A 0AA', false);
+test (isPostcodeDistrict, 'SW1A0AA', false);
+test (isPostcodeDistrict, 'E2 0AA', false);
+test (isPostcodeDistrict, 'E20AA', false);
+test (isPostcodeDistrict, 'E201AA', false);
+test (isPostcodeDistrict, 'SW1A', true);
+test (isPostcodeDistrict, 'E2', true);
+test (isPostcodeDistrict, 'E20', true);
+
+test (endsWithPostcode, 'Stuff.. SW1A 0AA', true);
+test (endsWithPostcode, 'Stuff.. SW1A0AA', true);
+test (endsWithPostcode, 'Stuff.. E2 0AA', true);
+test (endsWithPostcode, 'Stuff.. E20AA', true);
+test (endsWithPostcode, 'Stuff.. E201AA', true);
+test (endsWithPostcode, 'Stuff.. SW1A', true);
+test (endsWithPostcode, 'Stuff.. E2', true);
+test (endsWithPostcode, 'Stuff.. E20', true);
+//
+// test (isPc7, 'E2 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);
+// test (isPc7, 'SW1A 0AA', true);

--- a/server/location/index.js
+++ b/server/location/index.js
@@ -1,0 +1,183 @@
+const debug = require('debug')('kyf:location.server.index.js');
+
+// const { constituencyFromPostcode, locationInfoFromPostcode } = require ('./externals');
+const { isPc7, isPc8, isPostcodeDistrict, isFullPostcode, isPostcode, endsWithPostcode,
+pc7FromFullPostcode, pc8FromFullPostcode, districtFromFullPostcode, districtFromPostcodeDistrict, postcodeFromString,
+toStandardLatLong, toLatLong, isLeafletLatLng, latLongFromString, latLongFrom4dpLatLongString, roundToNearest } = require ('./helpers');
+const { officialLabourHandlesFromConstituency } = require ('./locationmatchers');
+const { fromPostcodesIo, fromGoogle, fromTwitter,
+  constituencyFromPostcode, locationInfoFromPostcode  } = require ('./requests');
+
+const LocationObject = ()=> ({
+  specificity : 0,
+  twitterString  : '',
+  defaultTwitterFollow : '@uklabour'
+});
+const noVerify = { verify : false };
+
+const cache = {
+  records : 0,
+
+  canonicalise : location => {
+    const latLong = toStandardLatLong(location);
+    if (latLong)
+      return(`${latLong.lng},${latLong.lat}`);                // see note in helpers.js
+    if (isPostcode(location))
+      return pc8FromFullPostcode(location) || districtFromPostcodeDistrict(location)
+    if (endsWithPostcode(location))
+      return postcodeFromString(location)
+    // and then the harder cases, eg London, Hackney, The World
+    return location
+  },
+
+  compress : x=> x,
+
+  uncompress : x=> x,
+
+  put : (location, result, options={ verify:true } ) => {
+    if (options.verify)
+      location = cache.canonicalise(location);
+    if (!cache[location]) {
+      cache[location] = cache.compress(result);
+      cache.records++;
+    }
+    // debug(cache);
+  },
+
+  get : (location, options={ verify:true } ) => {
+    if (options.verify)
+      location = cache.canonicalise(location);
+    return cache.uncompress(cache.location);
+  }
+
+}
+
+// Mutates resultObject by concatenating handles from listOfCLPsandPPCs.json
+const addOfficialLabourHandles = (resultObject, locationInfo) => {
+  if (locationInfo && locationInfo.parliamentary_constituency) {
+    if (!resultObject.twitterHandles)
+      resultObject.twitterHandles = [];
+    let handles = officialLabourHandlesFromConstituency(locationInfo.parliamentary_constituency) || []
+    handles.forEach ( handle =>
+        resultObject.twitterHandles.push(handle)
+    )
+  }
+}
+
+// locations is one of:
+// . query object, eg {pc='AB1 9XY', latlong=<leafletJS latlong>}
+// . pcd, pc7, pc8, latLong, leafletJS latlong
+// . a prioirty ordered array of the above
+const populateLocationObject = async (locations, options={} ) => {
+  let handles = [];
+  if (!Array.isArray(locations))
+    locations = [locations];
+
+  const possibles = locations
+    .map (async (location, idx) => {
+      const result = LocationObject();
+      if (!location)
+        return null
+      // NB currently does not cache failures well
+
+  // debug('\ntrying to convert ',idx,location);
+      if (typeof location !=='object') {
+        location = cache.canonicalise(location);
+
+        if (!cache[location])
+        { // debug('Not cached:',location)
+        }
+        else
+          // debug('found in cache:',cache.get(location, noVerify));
+
+          if (cache[location])
+            return cache.get(location, noVerify)
+      }
+  // debug(`canonicalised ${''}(if string): ${location}`);
+
+      // the only permissable objects are
+      // . latLng (leaflet.js)
+      // . or req.query object containing at least one of pc, pc7, pc8, pcd, latlong as properties
+      const fullPc = location.pc7 || location.pc8 || location.pc || location;
+      if (isFullPostcode(fullPc))
+        try {
+    debug('got pc:',fullPc);
+          let specificity;
+          const info = await locationInfoFromPostcode(fullPc)
+    debug(Object.keys(info));
+          if (info.region)
+            specificity = 1
+          if (isPostcodeDistrict(info.pcd))
+            specificity = 5
+          if (info.parliamentary_constituency)
+            specificity = 6
+          if (toLatLong(info.latLong) || isFullPostcode(info.pc || info.pc7 || info.pc8))
+            specificity = 10
+          // TODO: use GSS bits here from GSS converter
+
+          Object.assign (result, info, {specificity} );
+
+          // job done, don't examine other cases
+          cache.put(fullPc, result, noVerify);
+          debug('Successful lookup, got: ', info);
+          // don't retrieve handles from cache, we want fresh ones!
+          addOfficialLabourHandles (result, info);
+          return result
+        }
+        catch (err) {
+          if (err.message.endsWith('404')) {
+            if (typeof location==='string')
+              location = districtFromFullPostcode(fullPc)
+            else
+              location.pcd = location.pcd || districtFromFullPostcode(fullPc)
+          }
+          console.log(err);
+        }
+
+      if (result.specificity<5 && isPostcodeDistrict(location.pcd || location)) {
+        // TODO: use cache, google, etc, to get some sense from partial postcode if it is real
+        Object.assign (result, {
+          pcd : location.pcd || location,
+          specificity : 5
+        });
+        //  cache but don't return - we may get a better result
+      }
+
+      // TODO: other string types, or, eg, query.city
+
+      // NB using lowercase latlong, as it's a querystring
+      location = location.latlong || location.pcd || (typeof location === 'string') ? location : null
+
+// WHAT IF THE INFO'S NOT FROM LATLNG!!?
+      if (latLongFrom4dpLatLongString(location)) {
+        const info = locationInfoFromLatLong(location)
+        /// process info
+        Object.assign ( result, info, { specificity:10 } )
+        cache.put( location, result, noVerify );
+        // don't retrieve handles from cache, we want fresh ones!
+        addOfficialLabourHandles (result, locationInfo);
+        return result
+      }
+
+      if (options.useGoogle) {
+        // If useGoogle==true, use our API credits to try to get a more specific location from Google API
+        cache.put (location, result);
+      }
+
+      if (options.useTwitterContext) {
+        // Use context from eg user's tweets to attempt to guess location
+        // user data, eg screen name is received in options.useTwitterContext object
+      }
+      return result
+    }) ;
+
+  let bestLocation = (await Promise.all(possibles))
+    .filter (Boolean)
+    .sort ((a,b) => (b.specificity||0) - (a.specificity||0) )      // Specificity takes priority over input order
+
+  // debug('results:',bestLocation );
+
+  return bestLocation[0];
+};
+
+module.exports = { LocationObject, populateLocationObject, constituencyFromPostcode }

--- a/server/location/locationmatchers.js
+++ b/server/location/locationmatchers.js
@@ -1,0 +1,29 @@
+// TODO: move this file into ../matcher and integrate matchers
+const debug = require('debug')('kyf:location.matchers');
+
+const constituencyInfo = require ('./testdata/listOfCLPsandPPCs.json')
+
+const officialLabourHandlesFromConstituency = location => {
+  if (!location)
+    return [];
+
+  const constData=constituencyInfo[location];
+  if (!constData)
+    return [];
+
+  let handles = [];
+  let ppc = constData.ppc || [];
+  let clp = constData.clp || [];
+  if (!Array.isArray(ppc))
+    ppc = [ppc];
+  if (!Array.isArray(clp))
+    clp = [clp];
+    
+  handles.push(...ppc);
+  handles.push(...clp);
+  debug ('handles',handles);
+
+  return handles
+}
+
+module.exports = { officialLabourHandlesFromConstituency }

--- a/server/location/requests.js
+++ b/server/location/requests.js
@@ -1,0 +1,172 @@
+
+// postcodesio-client is an alternative, simpler library.
+// node-postcodes.io, remeber to pipe results through include nodePostcodesIoResultsShim
+
+const PostcodesIO = require('postcodesio-client');
+// const postcodesIo = new PostcodesIO('https://api.postcodes.io')
+const postcodesIo = require('node-postcodes.io');
+
+const { promiseyLog } = require ('./helpers');
+
+const constituencyInfo = require ('./testdata/listOfCLPsandPPCs.json');
+
+// Use these two config consts to take the data out of the XHR's result object,
+// in order to limit the info to be passed back to the cache.
+// 'default fields' is an array whose members can be field names as found in the remote API's result
+// object, of sub- (/sub- /sub-, etc) properties of that object.
+// 'field processors' are for those fields which require modification before storage
+// (eg pairing together into an array, or changing property name)
+// NB the field processor functions do NOT return meaningful info, but receive a 'report' object and mutate it.
+
+const postcodesIoDefaultFields = [ 'parliamentary_constituency', { codes : 'parliamentary_constituency' }, 'region']
+const postcodesIoDefaultFieldProcessors = [
+  (result, report) => { report.latLong = { lng : result.longitude, lat: result.latitude } },
+  (result, report) => { report.gss = result.codes.parliamentary_constituency },
+  (result, report) => { report.parliamentary_constituency = result.parliamentary_constituency },
+  (result, report) => { delete report.codes }
+]
+
+// Takes a Location Object
+const addConstituencyInfoToLocation = location => {
+  // TODO : Implement it ;)
+}
+
+// Takes a postcodes.io result record
+// NB Mutates the object!
+const addConstituencyInfoTo = result => {
+  // TODO: Typecheck input (eg was it array? error?)
+  const info = constituencyInfo[result.parliamentary_constituency];
+  console.log('info',info);
+  if (!info)
+    return false;
+  console.log(info);
+}
+
+// mutates the received object report
+const recursiveProcessor = (fields, result, report) =>  {
+  if (typeof fields === 'string')
+    report[fields] = result[fields]
+  else if (Array.isArray (fields)) {
+    fields.forEach (field => recursiveProcessor(field, result, report) )
+  }
+  else if (typeof fields === 'object') {
+    Object.keys(fields).forEach (key =>  {
+      report[key] = {};
+      recursiveProcessor(fields[key], result[key], report[key])
+    })
+  }
+}
+
+const handle404 = result => {
+  if (result===null || result.status===404)
+    console.log('should throw');
+  if (result===null)
+    throw new Error(`lookup request fail - 404`);
+  if (result.status===404)
+    throw new Error(`lookup request fail ${result.status}`);
+  return result
+};
+
+
+// NB there is a choice of two wrapper modules for Postcodes.io.
+// node-postcodes.io is more powerful, but requires this shim.
+const nodePostcodesIoResultsShim = result => {
+  if (result.status !== 200)
+    throw new Error(`HTTP request fail ${result.status}`);
+  if (Array.isArray (result.result))
+    return result.result.map (result=> result.result)   // Sorry, couldn't resist it ;)
+  return result.result
+}
+
+
+// fromPostcodesIo is currently:
+//  . set up for node-postcodes.io module (comment out ".then (nodePostcodesIoResultsShim)" to use postcodesio-client )
+//  . using postcodesIoDefaultFields & postcodesIoDefaultFieldProcessors, ie set up for API to respond
+//    with a single gss code and constituency name
+// TODO: make it general for batch lookup. Make constituencyFromPcioLookup a specific instance of it for single lookup.
+const fromPostcodesIo = async (location,
+  desiredFields = postcodesIoDefaultFields,
+  fieldProcessors = postcodesIoDefaultFieldProcessors
+)=> {
+  const report = {};
+  await postcodesIo
+  	.lookup(location)
+    .then (nodePostcodesIoResultsShim)
+    .then (handle404)
+    .then (result => result[0]!==undefined ? result[0] : result)    // Discard all results except the first - you don't want this!
+    .then (handle404) // repeated for the unpacked array result
+    .then (promiseyLog('before processing'))
+    .then (info=> {
+      recursiveProcessor (desiredFields, info, report);
+      fieldProcessors.forEach (processor=> {processor(info, report)} );
+      return report
+  	})
+    .then(promiseyLog('after processing'))
+    // TODO: distinguish errors
+    .catch (err=> {
+      if (err.message.endsWith('404'))
+        throw err;
+      console.log(err);
+    })
+
+  return report
+}
+
+const constituencyFromPcioLookup = async pc => {
+  const result = await fromPostcodesIo (pc) ;
+  return result
+}
+
+const constituencyFromPostcode = async pc => {
+  // TODO: check it's a good postcode
+  const result = await constituencyFromPcioLookup (pc)
+  return result
+}
+
+const locationInfoFromPostcode = async pc=> {
+  // TODO: check postcodes via local .csv files first
+  const result = await fromPostcodesIo(pc)
+    .catch (err=> {
+      if (err.message.endsWith('404')) {
+        // TODO: catch bad 404s resulting from bad postcodes
+        console.log(`Bad postcode - ${pc}`);
+      }
+      console.log(err);
+    }) ;
+  addConstituencyInfoTo (result);
+  return result
+}
+
+
+/// GOOGLE: - - - - - - - - - - - - - - -
+
+const fromGoogle = async (location)=> {
+  const result = {};
+
+  return result
+}
+
+
+/// TWITTER: - - - - - - - - - - - - - - -
+
+// Infer a location from Twitter context, eg tweets
+const fromTwitter = async (location, twitterData )=> {
+  const result = { specificity : 4 };
+  const { screen_name, id } = twitterData;
+
+  // do magic
+
+  return result
+}
+
+// If uncommented, these will be run when index.js imports the file.
+// They won;t output anything but will cause 404 errors, which won;t be caught, since
+// the try/ catch is in index.js
+
+// fromPostcodesIo ('PO123AA')
+// fromPostcodesIo ('PO12')
+// fromPostcodesIo ('XX99 3AA')
+// fromPostcodesIo (['XX99 3AA', 'PO12 3AB'])
+
+
+module.exports = { fromPostcodesIo, fromGoogle, fromTwitter, constituencyFromPostcode, locationInfoFromPostcode }

--- a/server/location/testcode/externals.js
+++ b/server/location/testcode/externals.js
@@ -1,0 +1,44 @@
+const postcodes = require('node-postcodes.io');
+
+const nodePostcodesIoShim = response => response.result;
+
+const lookupPc = async (pc, options = {}) => {
+  const result = await postcodes.lookup(pc, options)
+    .then (nodePostcodesIoShim);
+
+  return result
+}
+
+const constituencyFromPcioLookup = result => {
+  if (result === null || !result.codes || !result.codes.parliamentary_constituency)
+    throw new Error ('some kinda error');
+
+  const pcObj = {}
+  pcObj [result.codes.parliamentary_constituency] = result.parliamentary_constituency ;
+  return pcObj
+}
+
+const constituencyFromPostcode = async pc => {
+  // check it's a good postcode
+  return lookupPc (pc)
+    .then (constituencyFromPcioLookup)
+}
+
+const testPcs = [
+  'N4 3DL'
+]
+//
+// testPcs.forEach (pc => {
+//   console.log( lookupPc());
+// });
+
+let timer = Date.now()
+lookupPc ('N4 3DL')
+  .then (nodePostcodesIoShim)
+  .then (constituencyFromPcioLookup)
+  .then (result=> {
+    console.log(`${Date.now()-timer}ms:`);
+    console.log(result);
+  });
+
+module.exports = { constituencyFromPostcode }

--- a/server/location/testdata/listOfCLPsandPPCs.json
+++ b/server/location/testdata/listOfCLPsandPPCs.json
@@ -1,0 +1,3457 @@
+{
+  "North East Hertfordshire": {
+    "clp": [
+      "NEHertsLabour"
+    ]
+  },
+  "Blaydon": {
+    "ppc": "LizTwistMP",
+    "clp": []
+  },
+  "Thornbury and Yate": {
+    "clp": []
+  },
+  "South Antrim": {
+    "ppc": "roisinlynchsdlp",
+    "clp": []
+  },
+  "Belfast North": {
+    "clp": [
+      "LabourBelfast"
+    ]
+  },
+  "Fermanagh and South Tyrone": {
+    "ppc": "CllrAdamGannon",
+    "clp": []
+  },
+  "Ipswich": {
+    "ppc": "sandyofipswich",
+    "clp": [
+      "IpswichLabour"
+    ]
+  },
+  "Milton Keynes South": {
+    "ppc": "hfoneill",
+    "clp": [
+      "MKLabourParty"
+    ]
+  },
+  "Rochdale": {
+    "ppc": "tony4rochdale",
+    "clp": [
+      "tony4rochdale"
+    ]
+  },
+  "Neath": {
+    "clp": [
+      "NeathYL"
+    ]
+  },
+  "Leeds West": {
+    "ppc": "RachelReevesMP",
+    "clp": [
+      "LeedsWestLabour"
+    ]
+  },
+  "South Leicestershire": {
+    "clp": [
+      "SWLYoungLabour"
+    ]
+  },
+  "Ashton-under-Lyne": {
+    "ppc": "AngelaRayner",
+    "clp": [
+      "TSYLabour"
+    ]
+  },
+  "Epsom and Ewell": {
+    "clp": [
+      "ee_labour"
+    ]
+  },
+  "Walsall North": {
+    "ppc": "GillOgilvie",
+    "clp": [
+      "WalsallNorthLab"
+    ]
+  },
+  "Penistone and Stocksbridge": {
+    "ppc": "FrancyneJohnson",
+    "clp": [
+      "LabourPenistone"
+    ]
+  },
+  "New Forest East": {
+    "clp": [
+      "NFELabour"
+    ]
+  },
+  "Chipping Barnet": {
+    "ppc": "EmmaWhysall",
+    "clp": [
+      "ChippingLabour"
+    ]
+  },
+  "Kilmarnock and Loudoun": {
+    "ppc": "kevin4kl",
+    "clp": [
+      "KillieLabour"
+    ]
+  },
+  "Kettering": {
+    "ppc": "ClarePavitt1",
+    "clp": [
+      "LabourKettering",
+      "KetteringCLP",
+      "KetteringLabour"
+    ]
+  },
+  "Orkney and Shetland": {
+    "ppc": "CoillaDrake",
+    "clp": []
+  },
+  "Croydon North": {
+    "ppc": "SteveReedMP",
+    "clp": [
+      "CroydonNorthCLP"
+    ]
+  },
+  "Rossendale and Darwen": {
+    "ppc": "AlysonDBarnes",
+    "clp": [
+      "darwenlabour"
+    ]
+  },
+  "Angus": {
+    "clp": [
+      "AngusLabour"
+    ]
+  },
+  "Westmorland and Lonsdale": {
+    "clp": [
+      "slakeslabour"
+    ]
+  },
+  "Solihull": {
+    "clp": [
+      "Solihull_Labour",
+      "YLSolihull"
+    ]
+  },
+  "Totnes": {
+    "ppc": "L_Webberley",
+    "clp": [
+      "TotnesCLP"
+    ]
+  },
+  "Garston and Halewood": {
+    "ppc": "meaglemp",
+    "clp": [
+      "GandH_Labour"
+    ]
+  },
+  "Warwick and Leamington": {
+    "ppc": "MattWestern_",
+    "clp": [
+      "WarkandLeamCLP"
+    ]
+  },
+  "Chesterfield": {
+    "ppc": "tobyperkinsmp",
+    "clp": []
+  },
+  "Dundee West": {
+    "clp": [
+      "dundeelabour"
+    ]
+  },
+  "Exeter": {
+    "ppc": "BenPBradshaw",
+    "clp": [
+      "exeterlabour"
+    ]
+  },
+  "Harwich and North Essex": {
+    "clp": []
+  },
+  "Bristol North West": {
+    "ppc": "darrenpjones",
+    "clp": [
+      "BristolNWCLP"
+    ]
+  },
+  "Aberdeen South": {
+    "clp": [
+      "AberdeenLabour"
+    ]
+  },
+  "Edmonton": {
+    "clp": [
+      "Labour4Edmonton",
+      "EdmontonCLP",
+      "EdmontonLabour"
+    ]
+  },
+  "Hereford and South Herefordshire": {
+    "clp": [
+      "herefordlabour"
+    ]
+  },
+  "North East Bedfordshire": {
+    "clp": []
+  },
+  "Mid Norfolk": {
+    "ppc": "DrAdrianHeald",
+    "clp": [
+      "MidNorfolkLab"
+    ]
+  },
+  "Witham": {
+    "ppc": "martinedobor",
+    "clp": [
+      "BWLabour"
+    ]
+  },
+  "Eastbourne": {
+    "clp": [
+      "EastbourneCLP"
+    ]
+  },
+  "Heywood and Middleton": {
+    "ppc": "LizMcInnes_MP",
+    "clp": []
+  },
+  "Cardiff South and Penarth": {
+    "ppc": "SDoughtyMP"
+  },
+  "South Down": {
+    "clp": []
+  },
+  "Bolton South East": {
+    "clp": [
+      "Bolton_Labour"
+    ]
+  },
+  "Vale of Glamorgan": {
+    "ppc": "Bel4theVale",
+    "clp": [
+      "VoGLabour"
+    ]
+  },
+  "Morecambe and Lunesdale": {
+    "ppc": "LizziCollinge",
+    "clp": [
+      "LabourMorecambe"
+    ]
+  },
+  "Derby North": {
+    "clp": [
+      "LabourinDerby"
+    ]
+  },
+  "Winchester": {
+    "clp": [
+      "Winch_Labour"
+    ]
+  },
+  "Staffordshire Moorlands": {
+    "ppc": "DPriceLabour",
+    "clp": []
+  },
+  "Richmond Park": {
+    "clp": [
+      "richmondclp"
+    ]
+  },
+  "Esher and Walton": {
+    "clp": [
+      "EWLabourParty"
+    ]
+  },
+  "Milton Keynes North": {
+    "ppc": "CharlynnePullen",
+    "clp": [
+      "MKLabourParty"
+    ]
+  },
+  "Ogmore": {
+    "clp": [
+      "OgmoreYthLabour"
+    ]
+  },
+  "Southampton, Itchen": {
+    "ppc": "LabourLetts",
+    "clp": [
+      "sotonitchenlab"
+    ]
+  },
+  "Wolverhampton South West": {
+    "ppc": "SmithEleanor123",
+    "clp": []
+  },
+  "Pendle": {
+    "ppc": "Azhar4Pendle",
+    "clp": [
+      "PendleLabour"
+    ]
+  },
+  "Midlothian": {
+    "ppc": "DaniRowley",
+    "clp": [
+      "MidlothLabour"
+    ]
+  },
+  "City of Durham": {
+    "ppc": "marykfoy",
+    "clp": [
+      "CoDLabour"
+    ]
+  },
+  "Castle Point": {
+    "clp": [
+      "CastlePointLab"
+    ]
+  },
+  "Banff and Buchan": {
+    "clp": []
+  },
+  "Richmond (Yorks)": {
+    "clp": [
+      "YorksRichmond"
+    ]
+  },
+  "Edinburgh South": {
+    "ppc": "IanMurrayMP",
+    "clp": [
+      "EdinburghLabour"
+    ]
+  },
+  "Chippenham": {
+    "clp": [
+      "ChippenhamCLP"
+    ]
+  },
+  "Buckingham": {
+    "clp": [
+      "BuckinghamCLP"
+    ]
+  },
+  "Dumfriesshire, Clydesdale and Tweeddale": {
+    "clp": []
+  },
+  "Bradford East": {
+    "clp": [
+      "BfdEastLabour"
+    ]
+  },
+  "Sedgefield": {
+    "ppc": "VotePhilWilson",
+    "clp": [
+      "SedgefieldLab",
+      "SedgefieldCLP"
+    ]
+  },
+  "Stevenage": {
+    "ppc": "JillBorcherds",
+    "clp": [
+      "StevenageLabour"
+    ]
+  },
+  "Stourbridge": {
+    "ppc": "pete4stour",
+    "clp": [
+      "sbridgelabour"
+    ]
+  },
+  "Basingstoke": {
+    "ppc": "kerena27",
+    "clp": [
+      "BstokeLabour"
+    ]
+  },
+  "Bury St Edmunds": {
+    "clp": [
+      "burystedlabour"
+    ]
+  },
+  "Mid Bedfordshire": {
+    "ppc": "Meades4Labour",
+    "clp": []
+  },
+  "Clwyd South": {
+    "ppc": "susanelanjones",
+    "clp": [
+      "ClwydSouthLab"
+    ]
+  },
+  "High Peak": {
+    "clp": [
+      "LabourHighPeak"
+    ]
+  },
+  "Halifax": {
+    "clp": [
+      "HalifaxLabour"
+    ]
+  },
+  "Oxford East": {
+    "ppc": "AnnelieseDodds",
+    "clp": [
+      "Oxford_Labour"
+    ]
+  },
+  "Stalybridge and Hyde": {
+    "ppc": "jreynoldsMP",
+    "clp": [
+      "SandHLab"
+    ]
+  },
+  "Cardiff North": {
+    "ppc": "AnnaMcMorrin",
+    "clp": [
+      "CardiffNorthLAB"
+    ]
+  },
+  "Luton South": {
+    "ppc": "rach_hopkins",
+    "clp": [
+      "LutonSouthCLP"
+    ]
+  },
+  "Camborne and Redruth": {
+    "ppc": "Paul_Farmer",
+    "clp": [
+      "CRHLabour"
+    ]
+  },
+  "Alyn and Deeside": {
+    "ppc": "MarkTamiMP",
+    "clp": []
+  },
+  "Sittingbourne and Sheppey": {
+    "ppc": "ClivJoh",
+    "clp": [
+      "SittSheppLabour"
+    ]
+  },
+  "Warrington South": {
+    "ppc": "FaisalRashidMP",
+    "clp": [
+      "WarrSouthLab"
+    ]
+  },
+  "Tynemouth": {
+    "ppc": "alancampbellmp",
+    "clp": []
+  },
+  "Normanton, Pontefract and Castleford": {
+    "ppc": "YvetteCooperMP",
+    "clp": [
+      "NPCLabour"
+    ]
+  },
+  "North Shropshire": {
+    "clp": [
+      "NShropLabour"
+    ]
+  },
+  "Northampton North": {
+    "ppc": "Sally_Keeble",
+    "clp": []
+  },
+  "Blyth Valley": {
+    "ppc": "SusanDungworth",
+    "clp": []
+  },
+  "North West Hampshire": {
+    "clp": [
+      "NWHantsLabour"
+    ]
+  },
+  "Grantham and Stamford": {
+    "clp": [
+      "GranStamCLP"
+    ]
+  },
+  "Chichester": {
+    "clp": [
+      "ChiLabour_15"
+    ]
+  },
+  "Mole Valley": {
+    "clp": [
+      "MVLabourParty"
+    ]
+  },
+  "Bexleyheath and Crayford": {
+    "ppc": "Annaday4MP",
+    "clp": [
+      "bexcraylab"
+    ]
+  },
+  "Tamworth": {
+    "ppc": "chrisdbain",
+    "clp": [
+      "Tamworth_CLP"
+    ]
+  },
+  "South East Cornwall": {
+    "ppc": "Gareth4Labour",
+    "clp": [
+      "SECornwallCLP"
+    ]
+  },
+  "Hitchin and Harpenden": {
+    "ppc": "kftart",
+    "clp": [
+      "HitchHarpLabour"
+    ]
+  },
+  "Broxbourne": {
+    "clp": [
+      "broxlabour"
+    ]
+  },
+  "North Norfolk": {
+    "ppc": "LabourTCNorwich",
+    "clp": [
+      "nn_labour"
+    ]
+  },
+  "The Cotswolds": {
+    "clp": [
+      "cotswoldslabour"
+    ]
+  },
+  "Brentwood and Ongar": {
+    "ppc": "olydurose",
+    "clp": [
+      "BwdOngrLabour"
+    ]
+  },
+  "Hammersmith": {
+    "ppc": "hammersmithandy",
+    "clp": [
+      "HFLabour"
+    ]
+  },
+  "Mid Sussex": {
+    "clp": [
+      "MIDSUSSEXLABOUR"
+    ]
+  },
+  "Leeds North West": {
+    "ppc": "alexsobel",
+    "clp": [
+      "LeedsNWLabour"
+    ]
+  },
+  "Twickenham": {
+    "clp": [
+      "twickenhamclp"
+    ]
+  },
+  "Sheffield, Hallam": {
+    "ppc": "_OliviaBlake",
+    "clp": [
+      "ShefHallamLab"
+    ]
+  },
+  "Clacton": {
+    "clp": [
+      "ClactonLabour"
+    ]
+  },
+  "Ashfield": {
+    "ppc": "Nataliefleet",
+    "clp": [
+      "AshfieldLabour",
+      "ashfield_labour"
+    ]
+  },
+  "Kingston upon Hull North": {
+    "ppc": "DianaJohnsonMP",
+    "clp": []
+  },
+  "Bassetlaw": {
+    "ppc": "MorrisonKeir",
+    "clp": [
+      "BassetlawLabour"
+    ]
+  },
+  "Stretford and Urmston": {
+    "ppc": "KateGreenSU",
+    "clp": [
+      "SandULabour"
+    ]
+  },
+  "South Swindon": {
+    "ppc": "Sarah_C_Church",
+    "clp": [
+      "LabSouthSwindon"
+    ]
+  },
+  "Cheltenham": {
+    "ppc": "GP4Chelt",
+    "clp": [
+      "cheltlabour"
+    ]
+  },
+  "Mid Derbyshire": {
+    "clp": []
+  },
+  "North Down": {
+    "clp": [
+      "NorthDownLabour"
+    ]
+  },
+  "Bath": {
+    "ppc": "MikeDaviesLab",
+    "clp": [
+      "BathLabourParty"
+    ]
+  },
+  "Stoke-on-Trent North": {
+    "ppc": "RuthSmeeth",
+    "clp": []
+  },
+  "Stratford-on-Avon": {
+    "ppc": "FelixLing_",
+    "clp": [
+      "StratfordLabour"
+    ]
+  },
+  "Hertsmere": {
+    "ppc": "hollykal1965",
+    "clp": [
+      "HertsmereCLP"
+    ]
+  },
+  "Leeds North East": {
+    "ppc": "FabianLeedsNE",
+    "clp": [
+      "LeedsNE_CLP"
+    ]
+  },
+  "Dudley North": {
+    "ppc": "Dudley4D",
+    "clp": [
+      "DudleyLabGroup"
+    ]
+  },
+  "Chelmsford": {
+    "clp": [
+      "ChelmsfordLab"
+    ]
+  },
+  "Wokingham": {
+    "ppc": "AnnetteMedhurs2",
+    "clp": [
+      "WokinghamLabour"
+    ]
+  },
+  "Waveney": {
+    "ppc": "sunrisesonj",
+    "clp": [
+      "WaveneyLabour"
+    ]
+  },
+  "Thirsk and Malton": {
+    "clp": [
+      "tandmclp"
+    ]
+  },
+  "Chatham and Aylesford": {
+    "clp": [
+      "CandACLP"
+    ]
+  },
+  "Weston-Super-Mare": {
+    "ppc": "TimTaylorWeston",
+    "clp": [
+      "in_weston"
+    ]
+  },
+  "Scunthorpe": {
+    "ppc": "voteNicDakin",
+    "clp": [
+      "ScunnyLabour"
+    ]
+  },
+  "Forest of Dean": {
+    "ppc": "DimartinDi",
+    "clp": [
+      "FoDLabourParty"
+    ]
+  },
+  "Sheffield South East": {
+    "clp": []
+  },
+  "Sefton Central": {
+    "ppc": "Bill_Esterson",
+    "clp": [
+      "SeftonYoungLab"
+    ]
+  },
+  "Wansbeck": {
+    "ppc": "IanLaveryMP",
+    "clp": [
+      "WansbeckLabour"
+    ]
+  },
+  "Islington South and Finsbury": {
+    "ppc": "EmilyThornberry",
+    "clp": [
+      "callylabour"
+    ]
+  },
+  "South Holland and The Deepings": {
+    "ppc": "markpopple4SHD",
+    "clp": [
+      "LabourSHD"
+    ]
+  },
+  "East Devon": {
+    "clp": [
+      "EastDevonLabour"
+    ]
+  },
+  "East Londonderry": {
+    "ppc": "Hunter_SDLP",
+    "clp": []
+  },
+  "Gower": {
+    "ppc": "ToniaAntoniazzi",
+    "clp": [
+      "GowerCLP"
+    ]
+  },
+  "Stafford": {
+    "ppc": "StillJoyce",
+    "clp": [
+      "StaffordLabour"
+    ]
+  },
+  "Glenrothes": {
+    "clp": []
+  },
+  "Inverclyde": {
+    "ppc": "martinmccluskey",
+    "clp": [
+      "InverclydeCLP"
+    ]
+  },
+  "Harrow West": {
+    "ppc": "GarethThomasMP",
+    "clp": [
+      "HarrowLabour"
+    ]
+  },
+  "Liverpool, West Derby": {
+    "ppc": "Ian4WestDerby",
+    "clp": [
+      "WestDerbyCLP"
+    ]
+  },
+  "Ealing North": {
+    "ppc": "jamesmurray_ldn",
+    "clp": [
+      "EalingLabour"
+    ]
+  },
+  "Stirling": {
+    "clp": [
+      "LabourStirling"
+    ]
+  },
+  "Rochford and Southend East": {
+    "ppc": "AshleyDaltonRSE",
+    "clp": [
+      "SouthendLabour"
+    ]
+  },
+  "Newcastle upon Tyne North": {
+    "ppc": "CatMcKinnell",
+    "clp": [
+      "NewcastleLabour"
+    ]
+  },
+  "Lagan Valley": {
+    "ppc": "allyhaydock1",
+    "clp": [
+      "labourlagan"
+    ]
+  },
+  "Crewe and Nantwich": {
+    "ppc": "CreweLabour",
+    "clp": [
+      "CandNLabour"
+    ]
+  },
+  "Walthamstow": {
+    "ppc": "stellacreasy",
+    "clp": [
+      "stowlabour"
+    ]
+  },
+  "West Lancashire": {
+    "clp": [
+      "LancsLabour"
+    ]
+  },
+  "Rushcliffe": {
+    "ppc": "cheryl_pidgeon",
+    "clp": [
+      "RushcliffeLab"
+    ]
+  },
+  "St Helens North": {
+    "ppc": "ConorMcGinn",
+    "clp": [
+      "StHelensLabour"
+    ]
+  },
+  "Great Yarmouth": {
+    "clp": [
+      "gylabour"
+    ]
+  },
+  "Reading East": {
+    "clp": [
+      "ReadingLabour"
+    ]
+  },
+  "Bognor Regis and Littlehampton": {
+    "clp": [
+      "BRLLabour"
+    ]
+  },
+  "Birmingham, Yardley": {
+    "ppc": "jessphillips",
+    "clp": [
+      "Yardley_Labour"
+    ]
+  },
+  "South Cambridgeshire": {
+    "ppc": "DanGreef",
+    "clp": [
+      "SCambsLabour"
+    ]
+  },
+  "Welwyn Hatfield": {
+    "ppc": "NewbiggingRosie",
+    "clp": [
+      "WHLabour"
+    ]
+  },
+  "Southend West": {
+    "ppc": "AstonALine",
+    "clp": [
+      "SouthendWestCLP"
+    ]
+  },
+  "Beckenham": {
+    "clp": [
+      "BeckenhamLabour"
+    ]
+  },
+  "Wyre and Preston North": {
+    "ppc": "jolainscough",
+    "clp": [
+      "LabourWPN"
+    ]
+  },
+  "Dundee East": {
+    "clp": [
+      "dundeelabour"
+    ]
+  },
+  "Salisbury": {
+    "ppc": "1tomcorbin",
+    "clp": [
+      "salisburylabour",
+      "YL_Salisbury"
+    ]
+  },
+  "Colne Valley": {
+    "ppc": "Thelma_WalkerMP",
+    "clp": [
+      "labourcv"
+    ]
+  },
+  "Brighton, Pavilion": {
+    "clp": [
+      "PavilionLabour"
+    ]
+  },
+  "Birmingham, Perry Barr": {
+    "ppc": "khalid4PB",
+    "clp": [
+      "BhamPerryBarr"
+    ]
+  },
+  "Ilford North": {
+    "ppc": "wesstreeting",
+    "clp": [
+      "IlfordNorthCLP"
+    ]
+  },
+  "Kirkcaldy and Cowdenbeath": {
+    "ppc": "LesleyLaird",
+    "clp": []
+  },
+  "Wyre Forest": {
+    "ppc": "rlunn47",
+    "clp": [
+      "WyreForestLab"
+    ]
+  },
+  "Peterborough": {
+    "ppc": "LisaForbes_",
+    "clp": [
+      "LabourPBoro",
+      "Labour4Pboro"
+    ]
+  },
+  "Epping Forest": {
+    "clp": [
+      "eflabour"
+    ]
+  },
+  "South West Bedfordshire": {
+    "clp": []
+  },
+  "Wrexham": {
+    "ppc": "MaryWimbury",
+    "clp": [
+      "WRX_Labour"
+    ]
+  },
+  "Newark": {
+    "ppc": "JimBaggaley",
+    "clp": [
+      "NewarkLabour"
+    ]
+  },
+  "South Staffordshire": {
+    "clp": [
+      "SouthStaffsCLP"
+    ]
+  },
+  "Bournemouth East": {
+    "ppc": "CorrieDrew",
+    "clp": [
+      "BournemouthLP"
+    ]
+  },
+  "Bristol East": {
+    "ppc": "KerryMP",
+    "clp": [
+      "bristoleastlab",
+      "BristolEastCLP"
+    ]
+  },
+  "Weaver Vale": {
+    "ppc": "MikeAmesburyMP",
+    "clp": [
+      "WeaverValeLab"
+    ]
+  },
+  "Glasgow South West": {
+    "ppc": "MattKerrLabour",
+    "clp": []
+  },
+  "Edinburgh South West": {
+    "clp": [
+      "EdinburghLabour"
+    ]
+  },
+  "Witney": {
+    "clp": [
+      "WitneyLabourCLP"
+    ]
+  },
+  "Wigan": {
+    "ppc": "lisanandy",
+    "clp": [
+      "WiganLabour"
+    ]
+  },
+  "Llanelli": {
+    "ppc": "NiaGriffithMP",
+    "clp": [
+      "LlanelliLab",
+      "Amanwy"
+    ]
+  },
+  "Birmingham, Erdington": {
+    "clp": [
+      "LabourErdington"
+    ]
+  },
+  "Liverpool, Walton": {
+    "ppc": "DanCardenMP",
+    "clp": [
+      "LpoolWaltonCLP"
+    ]
+  },
+  "Ochil and South Perthshire": {
+    "clp": []
+  },
+  "Warrington North": {
+    "ppc": "charlotte2153",
+    "clp": [
+      "Warrington_Lab"
+    ]
+  },
+  "Lewisham East": {
+    "ppc": "JanetDaby",
+    "clp": []
+  },
+  "West Ham": {
+    "ppc": "lynbrownmp",
+    "clp": [
+      "WestHamLabour"
+    ]
+  },
+  "Altrincham and Sale West": {
+    "ppc": "AndrewHWestern",
+    "clp": []
+  },
+  "Hendon": {
+    "ppc": "DavidPintoD",
+    "clp": [
+      "HendonLabour"
+    ]
+  },
+  "Stockton South": {
+    "ppc": "PaulWilliamsLAB",
+    "clp": [
+      "StocktonSthLab"
+    ]
+  },
+  "Middlesbrough South and East Cleveland": {
+    "ppc": "laurendingsdale",
+    "clp": []
+  },
+  "Gordon": {
+    "clp": [
+      "ClpGordon"
+    ]
+  },
+  "Brigg and Goole": {
+    "ppc": "MrMajKhan",
+    "clp": [
+      "BriggGooleCLP"
+    ]
+  },
+  "Louth and Horncastle": {
+    "clp": []
+  },
+  "Wallasey": {
+    "ppc": "angelaeagle",
+    "clp": [
+      "CLPWallasey"
+    ]
+  },
+  "Gateshead": {
+    "ppc": "IanMearnsMP",
+    "clp": [
+      "GatesheadLabour"
+    ]
+  },
+  "Falkirk": {
+    "clp": [
+      "FalkirkLabour"
+    ]
+  },
+  "Kensington": {
+    "ppc": "emmadentcoad",
+    "clp": [
+      "KensingtonCLP"
+    ]
+  },
+  "Vale of Clwyd": {
+    "clp": [
+      "VOCLabour"
+    ]
+  },
+  "Birmingham, Hall Green": {
+    "clp": [
+      "HallLabour"
+    ]
+  },
+  "Birmingham, Ladywood": {
+    "ppc": "ShabanaMahmood",
+    "clp": [
+      "LadywoodCLP"
+    ]
+  },
+  "Oxford West and Abingdon": {
+    "clp": [
+      "Oxford_Labour"
+    ]
+  },
+  "West Bromwich West": {
+    "clp": []
+  },
+  "Camberwell and Peckham": {
+    "clp": [
+      "CambPeckLab"
+    ]
+  },
+  "Hartlepool": {
+    "clp": [
+      "Labour_Hpool"
+    ]
+  },
+  "Dudley South": {
+    "clp": [
+      "DudleySthLabour"
+    ]
+  },
+  "Stoke-on-Trent South": {
+    "clp": [
+      "SoTSouthCLP"
+    ]
+  },
+  "Sevenoaks": {
+    "clp": [
+      "SevenoaksCLP"
+    ]
+  },
+  "Truro and Falmouth": {
+    "ppc": "Jen4TruroAndFal",
+    "clp": []
+  },
+  "Halton": {
+    "ppc": "DerekTwiggMP",
+    "clp": [
+      "HaltonCLP"
+    ]
+  },
+  "Bradford South": {
+    "ppc": "JudithCummins",
+    "clp": [
+      "bradsouthlabour"
+    ]
+  },
+  "Lanark and Hamilton East": {
+    "ppc": "Andrew_Hilland",
+    "clp": []
+  },
+  "Newcastle-under-Lyme": {
+    "ppc": "CarlGreatbatch",
+    "clp": [
+      "NUL_Labour"
+    ]
+  },
+  "Broadland": {
+    "clp": [
+      "BroadlandLabour"
+    ]
+  },
+  "Dewsbury": {
+    "ppc": "paulasherriff",
+    "clp": [
+      "DewsburyLabour"
+    ]
+  },
+  "South West Surrey": {
+    "clp": [
+      "SurreyLabour"
+    ]
+  },
+  "Telford": {
+    "ppc": "trinagilman",
+    "clp": [
+      "Telfordlabour"
+    ]
+  },
+  "Huddersfield": {
+    "ppc": "BarrySheerman",
+    "clp": [
+      "HuddsLabour"
+    ]
+  },
+  "Finchley and Golders Green": {
+    "ppc": "RossSHouston",
+    "clp": [
+      "FGGLabour"
+    ]
+  },
+  "Rotherham": {
+    "ppc": "SarahChampionMP",
+    "clp": [
+      "RothYoungLabour",
+      "RotherhamLabour"
+    ]
+  },
+  "Coventry South": {
+    "ppc": "zarahsultana",
+    "clp": [
+      "CoventryLabour"
+    ]
+  },
+  "Feltham and Heston": {
+    "ppc": "SeemaMalhotra1",
+    "clp": [
+      "FandHLabour"
+    ]
+  },
+  "Stone": {
+    "ppc": "CllrStubbsNUL",
+    "clp": [
+      "StoneLabour",
+      "Stone_Labour"
+    ]
+  },
+  "Calder Valley": {
+    "ppc": "JoshFG",
+    "clp": [
+      "LabourCalderV"
+    ]
+  },
+  "Northampton South": {
+    "ppc": "CllrGarethEales",
+    "clp": [
+      "Npton_South_CLP"
+    ]
+  },
+  "Tooting": {
+    "ppc": "DrRosena",
+    "clp": [
+      "TootingLabour"
+    ]
+  },
+  "South Basildon and East Thurrock": {
+    "clp": []
+  },
+  "Croydon South": {
+    "ppc": "OlgaFitzRoy",
+    "clp": [
+      "CroydonSouthLab"
+    ]
+  },
+  "Ealing, Southall": {
+    "ppc": "VirendraSharma",
+    "clp": [
+      "ESLabour"
+    ]
+  },
+  "Berwick-upon-Tweed": {
+    "clp": [
+      "BerwickCLP"
+    ]
+  },
+  "Ross, Skye and Lochaber": {
+    "clp": []
+  },
+  "Leicester South": {
+    "ppc": "JonAshworth",
+    "clp": []
+  },
+  "Beverley and Holderness": {
+    "clp": [
+      "GeorgeMcManus4"
+    ]
+  },
+  "Cambridge": {
+    "ppc": "DanielZeichner",
+    "clp": [
+      "CambridgeLabour"
+    ]
+  },
+  "Holborn and St Pancras": {
+    "ppc": "Keir_Starmer",
+    "clp": [
+      "hstplabour"
+    ]
+  },
+  "Woking": {
+    "clp": [
+      "wokinglabour"
+    ]
+  },
+  "Washington and Sunderland West": {
+    "ppc": "SharonHodgsonMP",
+    "clp": []
+  },
+  "Motherwell and Wishaw": {
+    "ppc": "angela_feeney",
+    "clp": [
+      "MwellWishawLab"
+    ]
+  },
+  "Romsey and Southampton North": {
+    "clp": []
+  },
+  "Coventry North East": {
+    "clp": [
+      "CoventryLabour"
+    ]
+  },
+  "Hornsey and Wood Green": {
+    "ppc": "CatherineWest1",
+    "clp": [
+      "LabourHWG"
+    ]
+  },
+  "East Renfrewshire": {
+    "clp": []
+  },
+  "Sheffield, Heeley": {
+    "ppc": "LouHaigh",
+    "clp": [
+      "HeeleyLabour"
+    ]
+  },
+  "Sutton Coldfield": {
+    "clp": [
+      "SC_Labour"
+    ]
+  },
+  "North Durham": {
+    "ppc": "KevanJones",
+    "clp": [
+      "NWDurhamLabour"
+    ]
+  },
+  "North West Durham": {
+    "ppc": "LauraPidcockMP",
+    "clp": [
+      "NWDurhamLabour"
+    ]
+  },
+  "Wirral West": {
+    "clp": [
+      "WWLabour"
+    ]
+  },
+  "Mid Worcestershire": {
+    "ppc": "helengoth",
+    "clp": [
+      "MidWorcsCLP"
+    ]
+  },
+  "Dagenham and Rainham": {
+    "ppc": "JonCruddas_1",
+    "clp": [
+      "DandR_CLP"
+    ]
+  },
+  "Suffolk Coastal": {
+    "ppc": "C4meronM4tthews",
+    "clp": [
+      "SuffolkCoastLab"
+    ]
+  },
+  "Newbury": {
+    "clp": [
+      "newburyclp"
+    ]
+  },
+  "Loughborough": {
+    "ppc": "stuart4lboro",
+    "clp": [
+      "LboroLabour"
+    ]
+  },
+  "Barrow and Furness": {
+    "ppc": "ChrisAltree1",
+    "clp": [
+      "Barrowclp"
+    ]
+  },
+  "Haltemprice and Howden": {
+    "clp": [
+      "handhlabour"
+    ]
+  },
+  "Gedling": {
+    "ppc": "Vernon_Coaker",
+    "clp": [
+      "Gedling_Labour",
+      "GedlingYL"
+    ]
+  },
+  "Carmarthen West and South Pembrokeshire": {
+    "ppc": "MarcTierneyLab",
+    "clp": [
+      "CWaSP_Labour"
+    ]
+  },
+  "South Shields": {
+    "ppc": "EmmaLewellBuck",
+    "clp": [
+      "SShieldsLabour",
+      "SShields_Labour"
+    ]
+  },
+  "North Somerset": {
+    "clp": [
+      "NSLabour"
+    ]
+  },
+  "Ayr, Carrick and Cumnock": {
+    "clp": []
+  },
+  "Ynys Môn": {
+    "ppc": "Mary4Mon"
+  },
+  "Lincoln": {
+    "clp": [
+      "LincolnLabour"
+    ]
+  },
+  "Swansea West": {
+    "clp": [
+      "SwanseaLabour"
+    ]
+  },
+  "Moray": {
+    "ppc": "JoKirby32812563",
+    "clp": [
+      "MorayLabour"
+    ]
+  },
+  "Belfast West": {
+    "ppc": "Paul_Doherty__",
+    "clp": [
+      "LabourBelfast"
+    ]
+  },
+  "Ceredigion": {
+    "ppc": "CeredigionLab",
+    "clp": [
+      "CeredigionLab"
+    ]
+  },
+  "Amber Valley": {
+    "clp": []
+  },
+  "Chingford and Woodford Green": {
+    "ppc": "faizashaheen",
+    "clp": [
+      "cwg_labour"
+    ]
+  },
+  "Bridgwater and West Somerset": {
+    "clp": [
+      "karenhaywood4"
+    ]
+  },
+  "Stockport": {
+    "ppc": "NavPMishra",
+    "clp": [
+      "StockportCLP"
+    ]
+  },
+  "Caerphilly": {
+    "clp": [
+      "CaerphillyLab"
+    ]
+  },
+  "Cannock Chase": {
+    "clp": [
+      "LabourChase"
+    ]
+  },
+  "Bermondsey and Old Southwark": {
+    "ppc": "coyleneil",
+    "clp": [
+      "BOSLabour"
+    ]
+  },
+  "Derby South": {
+    "clp": [
+      "LabourinDerby"
+    ]
+  },
+  "Maidenhead": {
+    "clp": [
+      "Maidenheadlab",
+      "MCampaigns"
+    ]
+  },
+  "Knowsley": {
+    "ppc": "georgehowarthmp",
+    "clp": [
+      "LabourKnowsley"
+    ]
+  },
+  "Nottingham North": {
+    "ppc": "AlexNorrisNN",
+    "clp": [
+      "NottNorthLabour"
+    ]
+  },
+  "Burton": {
+    "clp": [
+      "BurtonLabour"
+    ]
+  },
+  "Hemsworth": {
+    "clp": [
+      "Hemsworth_CLP"
+    ]
+  },
+  "Cynon Valley": {
+    "clp": [
+      "CynonLabour"
+    ]
+  },
+  "North Herefordshire": {
+    "clp": [
+      "NHerefordLabour"
+    ]
+  },
+  "Wimbledon": {
+    "ppc": "jackieschneider",
+    "clp": [
+      "WimbledonLabour"
+    ]
+  },
+  "West Suffolk": {
+    "clp": [
+      "suffolklabour"
+    ]
+  },
+  "Strangford": {
+    "clp": []
+  },
+  "Runnymede and Weybridge": {
+    "ppc": "robertk16",
+    "clp": [
+      "runnymedelabour",
+      "WeybridgeLabour"
+    ]
+  },
+  "Erewash": {
+    "ppc": "catkinson80",
+    "clp": [
+      "ErewashLabour"
+    ]
+  },
+  "Aylesbury": {
+    "ppc": "LizHind3",
+    "clp": [
+      "aylesburylabour"
+    ]
+  },
+  "Blackpool North and Cleveleys": {
+    "ppc": "Chris4BNC",
+    "clp": [
+      "BNandCLab"
+    ]
+  },
+  "Putney": {
+    "ppc": "CllrFleur",
+    "clp": [
+      "PutneyLabour"
+    ]
+  },
+  "Boston and Skegness": {
+    "clp": []
+  },
+  "Aberconwy": {
+    "ppc": "Emily4Aberconwy",
+    "clp": [
+      "LabourAberconwy",
+      "AberconwyLabour"
+    ]
+  },
+  "Worthing West": {
+    "ppc": "BeccyCooper4Lab",
+    "clp": [
+      "WorthingWestLab"
+    ]
+  },
+  "Upper Bann": {
+    "clp": [
+      "UpperBannLabour"
+    ]
+  },
+  "North East Derbyshire": {
+    "ppc": "cpeace313",
+    "clp": [
+      "DerbysLabour"
+    ]
+  },
+  "Meon Valley": {
+    "clp": [
+      "MeonValleyCLP"
+    ]
+  },
+  "Stroud": {
+    "ppc": "DavidEDrew",
+    "clp": [
+      "Stroud_Labour"
+    ]
+  },
+  "Bromley and Chislehurst": {
+    "clp": [
+      "BromChisLabour"
+    ]
+  },
+  "Newry and Armagh": {
+    "ppc": "peterbyrnejnr",
+    "clp": []
+  },
+  "Morley and Outwood": {
+    "ppc": "Deanneferguson",
+    "clp": [
+      "MandOCLP"
+    ]
+  },
+  "Lancaster and Fleetwood": {
+    "ppc": "CatSmithMP",
+    "clp": []
+  },
+  "Guildford": {
+    "ppc": "grizelda1354",
+    "clp": [
+      "GuildfordLabour"
+    ]
+  },
+  "Rugby": {
+    "ppc": "Debbie_Bannigan",
+    "clp": [
+      "Rugby_Labour"
+    ]
+  },
+  "Newcastle upon Tyne East": {
+    "clp": [
+      "NewcastleLabour"
+    ]
+  },
+  "Fylde": {
+    "clp": [
+      "fyldelabour"
+    ]
+  },
+  "Rutland and Melton": {
+    "clp": []
+  },
+  "Ludlow": {
+    "clp": [
+      "LabourLudlow"
+    ]
+  },
+  "North East Fife": {
+    "clp": [
+      "NEFifeLabour"
+    ]
+  },
+  "North Swindon": {
+    "ppc": "kate_linnegar",
+    "clp": [
+      "swindonlabour"
+    ]
+  },
+  "Newport East": {
+    "ppc": "jessicamordenmp",
+    "clp": [
+      "NewportEastLab"
+    ]
+  },
+  "South Thanet": {
+    "ppc": "RGordon_Nesbitt",
+    "clp": [
+      "ThanetLab"
+    ]
+  },
+  "Sleaford and North Hykeham": {
+    "ppc": "LEdwardsShea",
+    "clp": []
+  },
+  "Rhondda": {
+    "ppc": "RhonddaBryant",
+    "clp": [
+      "RhonddaLabour"
+    ]
+  },
+  "Wirral South": {
+    "ppc": "Alison_McGovern",
+    "clp": [
+      "WirralSouthCLP"
+    ]
+  },
+  "Barking": {
+    "ppc": "margarethodge",
+    "clp": [
+      "barkinglabour"
+    ]
+  },
+  "Tewkesbury": {
+    "clp": [
+      "TewksLabour"
+    ]
+  },
+  "Rayleigh and Wickford": {
+    "clp": [
+      "raywicklabour"
+    ]
+  },
+  "Huntingdon": {
+    "ppc": "samuelsweek",
+    "clp": [
+      "HuntingdonCLP"
+    ]
+  },
+  "Vauxhall": {
+    "ppc": "FloEshalomi",
+    "clp": [
+      "VauxhallLabour"
+    ]
+  },
+  "West Tyrone": {
+    "ppc": "McCrossanMLA",
+    "clp": []
+  },
+  "Bolsover": {
+    "clp": [
+      "bolsover_clp"
+    ]
+  },
+  "Crawley": {
+    "ppc": "CllrPetesTweets",
+    "clp": [
+      "CrawleyLabour"
+    ]
+  },
+  "York Outer": {
+    "ppc": "AnnaPerrett",
+    "clp": []
+  },
+  "The Wrekin": {
+    "ppc": "dylan_prh4me",
+    "clp": [
+      "wrekinlabour"
+    ]
+  },
+  "Wolverhampton North East": {
+    "ppc": "EmmaReynoldsMP",
+    "clp": []
+  },
+  "Filton and Bradley Stoke": {
+    "ppc": "mthrel",
+    "clp": [
+      "fabslabour"
+    ]
+  },
+  "Plymouth, Sutton and Devonport": {
+    "ppc": "LukePollard",
+    "clp": []
+  },
+  "Blaenau Gwent": {
+    "clp": []
+  },
+  "Sheffield Central": {
+    "ppc": "PaulBlomfieldMP",
+    "clp": [
+      "Sheff_Cen_CLP"
+    ]
+  },
+  "Hackney South and Shoreditch": {
+    "clp": [
+      "SouthHackneyLab"
+    ]
+  },
+  "Nottingham East": {
+    "ppc": "NadiaWhittome",
+    "clp": [
+      "LabourSherwood"
+    ]
+  },
+  "Ribble Valley": {
+    "clp": [
+      "RVLabour"
+    ]
+  },
+  "Manchester Central": {
+    "ppc": "LucyMPowell",
+    "clp": [
+      "MancCentral"
+    ]
+  },
+  "Newcastle upon Tyne Central": {
+    "ppc": "ChiOnwurah",
+    "clp": []
+  },
+  "Central Devon": {
+    "clp": [
+      "LabCentDev"
+    ]
+  },
+  "Hampstead and Kilburn": {
+    "ppc": "TulipSiddiq",
+    "clp": [
+      "hampsteadlabour"
+    ]
+  },
+  "York Central": {
+    "ppc": "RachaelMaskell",
+    "clp": []
+  },
+  "Arundel and South Downs": {
+    "clp": [
+      "LabourHassocks"
+    ]
+  },
+  "North East Cambridgeshire": {
+    "ppc": "DianeMundill",
+    "clp": [
+      "NECambsLabour"
+    ]
+  },
+  "Eltham": {
+    "ppc": "CliveEfford",
+    "clp": [
+      "ElthamLabourPty"
+    ]
+  },
+  "Preseli Pembrokeshire": {
+    "ppc": "Philippa4Pembs",
+    "clp": [
+      "PembsLabour"
+    ]
+  },
+  "Chesham and Amersham": {
+    "clp": [
+      "CheshamAmersham"
+    ]
+  },
+  "Ealing Central and Acton": {
+    "ppc": "RupaHuq",
+    "clp": []
+  },
+  "Sheffield, Brightside and Hillsborough": {
+    "ppc": "GFurnissLabour",
+    "clp": []
+  },
+  "Maidstone and The Weald": {
+    "clp": [
+      "VotelabourM"
+    ]
+  },
+  "Bedford": {
+    "clp": [
+      "BedfordLabour"
+    ]
+  },
+  "Torfaen": {
+    "clp": [
+      "Torfaen_Labour"
+    ]
+  },
+  "Ruislip, Northwood and Pinner": {
+    "clp": []
+  },
+  "Kingston and Surbiton": {
+    "clp": []
+  },
+  "Spelthorne": {
+    "ppc": "pavitarmann",
+    "clp": [
+      "SpelthorneLabPy"
+    ]
+  },
+  "Wakefield": {
+    "ppc": "MaryCreaghMP",
+    "clp": [
+      "WakefieldLabour",
+      "LabourWakefield"
+    ]
+  },
+  "Stockton North": {
+    "ppc": "ACunninghamMP",
+    "clp": [
+      "StocktonLabour"
+    ]
+  },
+  "Bury North": {
+    "ppc": "BuryNorthLabour",
+    "clp": [
+      "BuryNorthLabour"
+    ]
+  },
+  "Havant": {
+    "clp": [
+      "HavantLabour"
+    ]
+  },
+  "North Warwickshire": {
+    "clp": [
+      "josephbevan96"
+    ]
+  },
+  "Lewisham West and Penge": {
+    "ppc": "elliereeves",
+    "clp": [
+      "CLPLewishamW_P"
+    ]
+  },
+  "Manchester, Gorton": {
+    "ppc": "Afzal4Gorton",
+    "clp": [
+      "McrGortonLab"
+    ]
+  },
+  "Gloucester": {
+    "ppc": "fran4gloucester",
+    "clp": [
+      "Glos_Labour"
+    ]
+  },
+  "Aldershot": {
+    "ppc": "abby_king96",
+    "clp": [
+      "LabourAldershot"
+    ]
+  },
+  "Oldham East and Saddleworth": {
+    "clp": [
+      "OldhamClp"
+    ]
+  },
+  "Wycombe": {
+    "ppc": "CllrKhalilAhmed",
+    "clp": [
+      "WycombeLabour"
+    ]
+  },
+  "Mid Dorset and North Poole": {
+    "ppc": "BournemouthLP",
+    "clp": []
+  },
+  "North Dorset": {
+    "ppc": "Pat4NorthDorset",
+    "clp": [
+      "ndorsetlabour"
+    ]
+  },
+  "Darlington": {
+    "clp": [
+      "Darlolabour"
+    ]
+  },
+  "Enfield, Southgate": {
+    "ppc": "Bambos4MP",
+    "clp": []
+  },
+  "Halesowen and Rowley Regis": {
+    "ppc": "ian4handrr",
+    "clp": [
+      "Hales_RowleyCLP"
+    ]
+  },
+  "Eddisbury": {
+    "clp": [
+      "eddisburylabour"
+    ]
+  },
+  "Carshalton and Wallington": {
+    "clp": []
+  },
+  "Redditch": {
+    "ppc": "redditchrebecca",
+    "clp": [
+      "ReddLab"
+    ]
+  },
+  "Slough": {
+    "clp": [
+      "SloughLabour"
+    ]
+  },
+  "North Thanet": {
+    "clp": [
+      "NThanetLP"
+    ]
+  },
+  "East Hampshire": {
+    "clp": []
+  },
+  "Easington": {
+    "ppc": "grahamemorris",
+    "clp": [
+      "EasingtonParty",
+      "EasingtonYL"
+    ]
+  },
+  "Leeds Central": {
+    "ppc": "hilarybennmp",
+    "clp": [
+      "LeedsCentralYL"
+    ]
+  },
+  "Gravesham": {
+    "ppc": "drlsullivan",
+    "clp": [
+      "graveshamlabour"
+    ]
+  },
+  "Tunbridge Wells": {
+    "ppc": "antonioeweiss",
+    "clp": [
+      "twlabour"
+    ]
+  },
+  "Blackburn": {
+    "ppc": "Kate_HollernMP",
+    "clp": [
+      "blackburnlabour"
+    ]
+  },
+  "Colchester": {
+    "ppc": "Tina4Colchester",
+    "clp": [
+      "ColchesterLab"
+    ]
+  },
+  "Arfon": {
+    "ppc": "SteffieSioned",
+    "clp": [
+      "Llafur_Arfon"
+    ]
+  },
+  "Harlow": {
+    "ppc": "Laura4Harlow",
+    "clp": [
+      "HarlowLabour"
+    ]
+  },
+  "Doncaster North": {
+    "ppc": "Ed_Miliband",
+    "clp": [
+      "DoncasterCLP"
+    ]
+  },
+  "Congleton": {
+    "clp": [
+      "CongletonLabour"
+    ]
+  },
+  "Broxtowe": {
+    "ppc": "Greg4Broxtowe",
+    "clp": [
+      "broxtowelabour"
+    ]
+  },
+  "Bristol West": {
+    "ppc": "ThangamMP",
+    "clp": [
+      "bristolwestlab"
+    ]
+  },
+  "Plymouth, Moor View": {
+    "ppc": "CharlotteHollo",
+    "clp": []
+  },
+  "Luton North": {
+    "ppc": "SarahOwen_",
+    "clp": [
+      "ClpLuton"
+    ]
+  },
+  "Yeovil": {
+    "ppc": "LedlieTerry",
+    "clp": [
+      "LabourYeovil"
+    ]
+  },
+  "Blackpool South": {
+    "ppc": "GordonMarsden",
+    "clp": [
+      "BlackpoolSthLab"
+    ]
+  },
+  "Southampton, Test": {
+    "clp": []
+  },
+  "Newport West": {
+    "ppc": "RuthNewportWest",
+    "clp": [
+      "nptwestlab"
+    ]
+  },
+  "Lewisham, Deptford": {
+    "ppc": "vickyfoxcroft",
+    "clp": [
+      "LewDeptLabour"
+    ]
+  },
+  "Streatham": {
+    "ppc": "BellRibeiroAddy",
+    "clp": [
+      "StreathamLabour"
+    ]
+  },
+  "Lewes": {
+    "clp": [
+      "LewesLabour"
+    ]
+  },
+  "Wantage": {
+    "clp": [
+      "WantLabour"
+    ]
+  },
+  "Bradford West": {
+    "clp": [
+      "brdfdwestlabour"
+    ]
+  },
+  "Scarborough and Whitby": {
+    "ppc": "HugoLabour",
+    "clp": [
+      "scarbwhitbyCLP"
+    ]
+  },
+  "Middlesbrough": {
+    "ppc": "AndyMcDonaldMP",
+    "clp": [
+      "borolabour"
+    ]
+  },
+  "Watford": {
+    "ppc": "Chris_Ostro",
+    "clp": [
+      "WatfordLabour"
+    ]
+  },
+  "Maldon": {
+    "clp": [
+      "MaldonLabour"
+    ]
+  },
+  "Islington North": {
+    "ppc": "jeremycorbyn",
+    "clp": [
+      "IslingtonNorth"
+    ]
+  },
+  "Cardiff Central": {
+    "ppc": "JoStevensLabour",
+    "clp": [
+      "CardiffCentLAB"
+    ]
+  },
+  "Reigate": {
+    "clp": [
+      "ReigateLabour"
+    ]
+  },
+  "Carlisle": {
+    "ppc": "ruthalcroft",
+    "clp": [
+      "Labour_Carlisle"
+    ]
+  },
+  "Berwickshire, Roxburgh and Selkirk": {
+    "clp": []
+  },
+  "Keighley": {
+    "ppc": "KeighleyLabour",
+    "clp": [
+      "KeighleyLabour"
+    ]
+  },
+  "Hayes and Harlington": {
+    "ppc": "johnmcdonnellMP",
+    "clp": []
+  },
+  "Torbay": {
+    "clp": []
+  },
+  "Kingston upon Hull West and Hessle": {
+    "ppc": "EmmaHardyMP",
+    "clp": []
+  },
+  "Tiverton and Honiton": {
+    "clp": [
+      "AndHoniton"
+    ]
+  },
+  "Birmingham, Selly Oak": {
+    "ppc": "steve_mccabe",
+    "clp": [
+      "WaSOLabourParty"
+    ]
+  },
+  "North Ayrshire and Arran": {
+    "clp": []
+  },
+  "Blackley and Broughton": {
+    "clp": [
+      "BandBCLP"
+    ]
+  },
+  "Inverness, Nairn, Badenoch and Strathspey": {
+    "ppc": "LewisIWhyte",
+    "clp": []
+  },
+  "East Yorkshire": {
+    "clp": [
+      "EYLabour"
+    ]
+  },
+  "Norwich South": {
+    "ppc": "labourlewis",
+    "clp": [
+      "NorwichLabour"
+    ]
+  },
+  "Orpington": {
+    "clp": [
+      "orpingtonlabour"
+    ]
+  },
+  "Dartford": {
+    "clp": [
+      "Dartford_Labour"
+    ]
+  },
+  "Bury South": {
+    "ppc": "Lucy4BurySouth",
+    "clp": [
+      "BurySouthCLP"
+    ]
+  },
+  "Linlithgow and East Falkirk": {
+    "clp": []
+  },
+  "Bracknell": {
+    "clp": [
+      "BracknellLabour"
+    ]
+  },
+  "Monmouth": {
+    "ppc": "Yvonne4Monmouth",
+    "clp": [
+      "MonmouthCLP"
+    ]
+  },
+  "Batley and Spen": {
+    "ppc": "TracyBrabin",
+    "clp": [
+      "BatleyLabour"
+    ]
+  },
+  "Leicester East": {
+    "clp": [
+      "EastClp"
+    ]
+  },
+  "Foyle": {
+    "ppc": "columeastwood",
+    "clp": [
+      "FoyleLabourNI"
+    ]
+  },
+  "Chorley": {
+    "clp": [
+      "ChorleyLabour"
+    ]
+  },
+  "Mansfield": {
+    "ppc": "Sonya_Ward",
+    "clp": [
+      "mansfieldwarsop",
+      "mansfieldlabour"
+    ]
+  },
+  "Leyton and Wanstead": {
+    "ppc": "JohnCryerMP",
+    "clp": [
+      "leytonwanstead"
+    ]
+  },
+  "Daventry": {
+    "clp": [
+      "DaventryCLP"
+    ]
+  },
+  "Hornchurch and Upminster": {
+    "ppc": "TeleLawal",
+    "clp": [
+      "HULabour"
+    ]
+  },
+  "South Northamptonshire": {
+    "clp": [
+      "S_Northants_CLP"
+    ]
+  },
+  "Glasgow Central": {
+    "ppc": "FatenH4Labour",
+    "clp": []
+  },
+  "Bootle": {
+    "ppc": "Peter_Dowd",
+    "clp": [
+      "LabourinBootle"
+    ]
+  },
+  "Cleethorpes": {
+    "clp": [
+      "ClpsLabour"
+    ]
+  },
+  "North Antrim": {
+    "clp": []
+  },
+  "Devizes": {
+    "clp": [
+      "devizeslabour"
+    ]
+  },
+  "Nuneaton": {
+    "ppc": "zoe_mayou",
+    "clp": [
+      "NunLabour",
+      "NuneatonLabour"
+    ]
+  },
+  "Mid Ulster": {
+    "ppc": "DENISEJOHNSTO10",
+    "clp": []
+  },
+  "Hastings and Rye": {
+    "ppc": "PeterchowneyHR",
+    "clp": [
+      "HastingsRyeLab"
+    ]
+  },
+  "Livingston": {
+    "ppc": "KaneCaitlin93",
+    "clp": []
+  },
+  "Walsall South": {
+    "clp": [
+      "WalsallLabour"
+    ]
+  },
+  "Edinburgh East": {
+    "ppc": "SheilaGilmore49",
+    "clp": [
+      "EdinEastLabour"
+    ]
+  },
+  "Braintree": {
+    "ppc": "JoshuaGarfield",
+    "clp": [
+      "BWLabour"
+    ]
+  },
+  "Horsham": {
+    "clp": [
+      "horshamlabour"
+    ]
+  },
+  "Harrogate and Knaresborough": {
+    "ppc": "MarkJSewards",
+    "clp": [
+      "LabourHarrogate"
+    ]
+  },
+  "Denton and Reddish": {
+    "ppc": "GwynneMP",
+    "clp": [
+      "ReddishLabour"
+    ]
+  },
+  "St Austell and Newquay": {
+    "ppc": "Flick_Cornwall",
+    "clp": [
+      "LabourStan"
+    ]
+  },
+  "Warley": {
+    "ppc": "spellar",
+    "clp": [
+      "LabourWarley"
+    ]
+  },
+  "Cardiff West": {
+    "ppc": "KevinBrennanMP",
+    "clp": [
+      "CardiffWestLAB"
+    ]
+  },
+  "Great Grimsby": {
+    "ppc": "OnnMel",
+    "clp": []
+  },
+  "Kingston upon Hull East": {
+    "ppc": "KarlTurnerMP",
+    "clp": []
+  },
+  "New Forest West": {
+    "ppc": "LabourNFW",
+    "clp": [
+      "LabourNFW"
+    ]
+  },
+  "Doncaster Central": {
+    "clp": [
+      "doncentralclp"
+    ]
+  },
+  "South Derbyshire": {
+    "clp": [
+      "SDLabour"
+    ]
+  },
+  "Brent Central": {
+    "ppc": "DawnButlerBrent",
+    "clp": [
+      "brentcentrallab"
+    ]
+  },
+  "Belfast South": {
+    "ppc": "ClaireHanna",
+    "clp": [
+      "LabourBelfast"
+    ]
+  },
+  "Cumbernauld, Kilsyth and Kirkintilloch East": {
+    "clp": []
+  },
+  "North Wiltshire": {
+    "ppc": "J_L_Fisher",
+    "clp": [
+      "NWiltsLabour"
+    ]
+  },
+  "East Ham": {
+    "ppc": "stephenctimms",
+    "clp": [
+      "easthamlabour"
+    ]
+  },
+  "Bolton West": {
+    "ppc": "JulieHilling",
+    "clp": [
+      "BoltonWestCLP"
+    ]
+  },
+  "Oldham West and Royton": {
+    "ppc": "JimfromOldham",
+    "clp": [
+      "OldhamRoytonCLP"
+    ]
+  },
+  "Aberdeen North": {
+    "ppc": "NurulForNorth",
+    "clp": []
+  },
+  "Ashford": {
+    "clp": [
+      "AshfordLabour"
+    ]
+  },
+  "Beaconsfield": {
+    "ppc": "AlexaCollinsDes",
+    "clp": [
+      "BeaconsfieldLab"
+    ]
+  },
+  "North Devon": {
+    "clp": [
+      "NDLabourParty"
+    ]
+  },
+  "Clwyd West": {
+    "ppc": "JoThomas_",
+    "clp": [
+      "ClwydWestLabour"
+    ]
+  },
+  "Corby": {
+    "ppc": "BethMiller91",
+    "clp": [
+      "LabourCorby"
+    ]
+  },
+  "East Dunbartonshire": {
+    "ppc": "Callum4EastDun",
+    "clp": [
+      "ED_Labour_Party"
+    ]
+  },
+  "Greenwich and Woolwich": {
+    "ppc": "mtpennycook",
+    "clp": [
+      "greenwichlabour"
+    ]
+  },
+  "St Helens South and Whiston": {
+    "clp": [
+      "SHS_WLabour"
+    ]
+  },
+  "East Antrim": {
+    "ppc": "a_margaretanne",
+    "clp": []
+  },
+  "Ellesmere Port and Neston": {
+    "ppc": "justinmadders",
+    "clp": []
+  },
+  "Windsor": {
+    "clp": [
+      "windsorlabour"
+    ]
+  },
+  "Portsmouth North": {
+    "clp": [
+      "PompeyLabour"
+    ]
+  },
+  "Rochester and Strood": {
+    "clp": [
+      "RSLabour"
+    ]
+  },
+  "South West Norfolk": {
+    "clp": [
+      "SWNCLP"
+    ]
+  },
+  "Leeds East": {
+    "ppc": "RichardBurgon",
+    "clp": [
+      "EastLeedsLabour",
+      "LeedsEastLP"
+    ]
+  },
+  "North Cornwall": {
+    "ppc": "joyinthisplace",
+    "clp": [
+      "CommsNCCLP"
+    ]
+  },
+  "West Dunbartonshire": {
+    "ppc": "jeananneforWD",
+    "clp": [
+      "WDCLabourGroup"
+    ]
+  },
+  "Pontypridd": {
+    "ppc": "AlexDaviesJones",
+    "clp": [
+      "teamponty"
+    ]
+  },
+  "Shipley": {
+    "ppc": "JoPike3",
+    "clp": [
+      "ShipleyLabour"
+    ]
+  },
+  "Aberavon": {
+    "ppc": "SKinnock",
+    "clp": [
+      "AberavonLabour"
+    ]
+  },
+  "Basildon and Billericay": {
+    "clp": []
+  },
+  "Brentford and Isleworth": {
+    "ppc": "RuthCadbury",
+    "clp": [
+      "BandILabour"
+    ]
+  },
+  "Wentworth and Dearne": {
+    "ppc": "JohnHealey_MP",
+    "clp": [
+      "WD_Labour"
+    ]
+  },
+  "Bishop Auckland": {
+    "ppc": "HelenGoodmanMP",
+    "clp": [
+      "BishopA_CLP"
+    ]
+  },
+  "Folkestone and Hythe": {
+    "clp": [
+      "FH4Labour"
+    ]
+  },
+  "Swansea East": {
+    "ppc": "carolynharris24",
+    "clp": [
+      "SwanseaEastclp"
+    ]
+  },
+  "Hazel Grove": {
+    "ppc": "Tony2Wilson",
+    "clp": [
+      "HazelGrove_Lab"
+    ]
+  },
+  "Hexham": {
+    "ppc": "vote_penny",
+    "clp": [
+      "LabourHexhamCLP"
+    ]
+  },
+  "Pudsey": {
+    "ppc": "JaneAitchison",
+    "clp": [
+      "PudseyLabour"
+    ]
+  },
+  "East Kilbride, Strathaven and Lesmahagow": {
+    "ppc": "Mcadams4Labour",
+    "clp": []
+  },
+  "Makerfield": {
+    "ppc": "Y_FovargueMP",
+    "clp": [
+      "MakerfieldCLP"
+    ]
+  },
+  "Stoke-on-Trent Central": {
+    "ppc": "gareth_snell",
+    "clp": []
+  },
+  "Harborough": {
+    "ppc": "CeliaHibbert",
+    "clp": [
+      "HarboroughLP"
+    ]
+  },
+  "Workington": {
+    "clp": [
+      "WorkingtonCLP"
+    ]
+  },
+  "Elmet and Rothwell": {
+    "clp": [
+      "ERLabour"
+    ]
+  },
+  "Edinburgh North and Leith": {
+    "ppc": "GJMunro26",
+    "clp": [
+      "NorthandLeithLP"
+    ]
+  },
+  "Copeland": {
+    "ppc": "TonyForCopeland",
+    "clp": [
+      "LabourCopeland"
+    ]
+  },
+  "Shrewsbury and Atcham": {
+    "clp": [
+      "ShrewsLabour"
+    ]
+  },
+  "Wythenshawe and Sale East": {
+    "ppc": "MikeKaneMP",
+    "clp": [
+      "WSELabourParty"
+    ]
+  },
+  "Glasgow South": {
+    "ppc": "JohannLamont",
+    "clp": [
+      "GSouthLabour"
+    ]
+  },
+  "Paisley and Renfrewshire South": {
+    "ppc": "MoiraRamage",
+    "clp": []
+  },
+  "North West Cambridgeshire": {
+    "clp": []
+  },
+  "Bromsgrove": {
+    "clp": [
+      "BromsgroveLab"
+    ]
+  },
+  "Edinburgh West": {
+    "ppc": "Bolton4EdinWest",
+    "clp": [
+      "EdWestCLP"
+    ]
+  },
+  "Old Bexley and Sidcup": {
+    "ppc": "Dave_Tingle",
+    "clp": [
+      "Sidcup_Labour"
+    ]
+  },
+  "Croydon Central": {
+    "ppc": "LabourSJ",
+    "clp": []
+  },
+  "Thurrock": {
+    "ppc": "TheJohnKent",
+    "clp": [
+      "thurrocklabour"
+    ]
+  },
+  "Bosworth": {
+    "ppc": "RMiddletonUK",
+    "clp": [
+      "LabourBosworth",
+      "BosworthLabour"
+    ]
+  },
+  "Chelsea and Fulham": {
+    "ppc": "MatthewUberoi",
+    "clp": []
+  },
+  "Liverpool, Wavertree": {
+    "ppc": "PaulaBarker1",
+    "clp": [
+      "WavertreeCLP"
+    ]
+  },
+  "Rutherglen and Hamilton West": {
+    "ppc": "Gedk",
+    "clp": []
+  },
+  "Brighton, Kemptown": {
+    "ppc": "lloyd_rm",
+    "clp": [
+      "KemptownLabour"
+    ]
+  },
+  "Hackney North and Stoke Newington": {
+    "ppc": "HackneyAbbott",
+    "clp": [
+      "HackneyNorthLab"
+    ]
+  },
+  "Charnwood": {
+    "clp": [
+      "CharnwoodClp"
+    ]
+  },
+  "Newton Abbot": {
+    "ppc": "james_labour",
+    "clp": [
+      "NewtonAbbotCLP"
+    ]
+  },
+  "East Worthing and Shoreham": {
+    "ppc": "fireylivs",
+    "clp": []
+  },
+  "Christchurch": {
+    "ppc": "MrAndyDunne",
+    "clp": [
+      "ChristchurchLab"
+    ]
+  },
+  "Tonbridge and Malling": {
+    "clp": [
+      "lab_ton_malling"
+    ]
+  },
+  "Sherwood": {
+    "ppc": "jerryhague01",
+    "clp": [
+      "LabourSherwood"
+    ]
+  },
+  "South East Cambridgeshire": {
+    "ppc": "JamesBullLabour",
+    "clp": [
+      "SECambsLabour"
+    ]
+  },
+  "Faversham and Mid Kent": {
+    "clp": [
+      "FavershamLabour"
+    ]
+  },
+  "Don Valley": {
+    "ppc": "CarolineFlintMP",
+    "clp": [
+      "DonValleyCLP"
+    ]
+  },
+  "Glasgow North West": {
+    "ppc": "PJFerguson18",
+    "clp": []
+  },
+  "Cities of London and Westminster": {
+    "ppc": "Gordon4Cities",
+    "clp": [
+      "WestminsterCLP"
+    ]
+  },
+  "Tottenham": {
+    "ppc": "DavidLammy",
+    "clp": [
+      "TottenhamLabour"
+    ]
+  },
+  "Wealden": {
+    "ppc": "angie4wealden",
+    "clp": [
+      "WealdenLabour"
+    ]
+  },
+  "Selby and Ainsty": {
+    "clp": [
+      "selbylabour"
+    ]
+  },
+  "Kingswood": {
+    "ppc": "NBJ4KINGSWOOD",
+    "clp": []
+  },
+  "Manchester, Withington": {
+    "ppc": "JeffSmithetc",
+    "clp": [
+      "WithingtonCLP"
+    ]
+  },
+  "Brecon and Radnorshire": {
+    "ppc": "CllrTomDavies",
+    "clp": []
+  },
+  "Redcar": {
+    "ppc": "annaturley",
+    "clp": []
+  },
+  "Airdrie and Shotts": {
+    "ppc": "AirdrieShottsLP",
+    "clp": [
+      "AirdrieShottsLP"
+    ]
+  },
+  "Hove": {
+    "ppc": "peterkyle",
+    "clp": [
+      "HoveLabourParty"
+    ]
+  },
+  "Mitcham and Morden": {
+    "ppc": "Siobhain_Mc",
+    "clp": [
+      "MMLabour"
+    ]
+  },
+  "Central Suffolk and North Ipswich": {
+    "clp": []
+  },
+  "Banbury": {
+    "clp": [
+      "BanburyLabour"
+    ]
+  },
+  "Bexhill and Battle": {
+    "clp": [
+      "BandBLabour"
+    ]
+  },
+  "Hemel Hempstead": {
+    "ppc": "nabila4hemel",
+    "clp": [
+      "Hemellabour"
+    ]
+  },
+  "Somerton and Frome": {
+    "ppc": "sean_labour",
+    "clp": [
+      "FromeLabour"
+    ]
+  },
+  "Uxbridge and South Ruislip": {
+    "ppc": "ARMilani_",
+    "clp": [
+      "UxbridgeLabour"
+    ]
+  },
+  "Hertford and Stortford": {
+    "clp": [
+      "HertStortLabour",
+      "HertStortLabCLP"
+    ]
+  },
+  "Merthyr Tydfil and Rhymney": {
+    "clp": [
+      "MTR_LabourParty"
+    ]
+  },
+  "St Ives": {
+    "clp": [
+      "StIvesCLP"
+    ]
+  },
+  "Southport": {
+    "ppc": "LizSavagelabour",
+    "clp": [
+      "SouthportLabour"
+    ]
+  },
+  "Perth and North Perthshire": {
+    "clp": []
+  },
+  "Dwyfor Meirionnydd": {
+    "clp": []
+  },
+  "Dunfermline and West Fife": {
+    "ppc": "cara_hilton",
+    "clp": []
+  },
+  "Bolton North East": {
+    "ppc": "DavidCrausby",
+    "clp": [
+      "BoltonNELabour"
+    ]
+  },
+  "Portsmouth South": {
+    "ppc": "StephenMorganMP",
+    "clp": [
+      "PompeyLabour"
+    ]
+  },
+  "Surrey Heath": {
+    "clp": [
+      "SurreyHeathLab"
+    ]
+  },
+  "Leigh": {
+    "ppc": "JoPlattMP",
+    "clp": [
+      "LeighYoungLab"
+    ]
+  },
+  "Houghton and Sunderland South": {
+    "ppc": "bphillipsonMP",
+    "clp": []
+  },
+  "Sunderland Central": {
+    "ppc": "JulieElliottMP",
+    "clp": []
+  },
+  "Hyndburn": {
+    "ppc": "GrahamJones_MP",
+    "clp": [
+      "Hyndburn_Labour"
+    ]
+  },
+  "Bridgend": {
+    "ppc": "sarah4bridgend",
+    "clp": [
+      "LabourBridgend"
+    ]
+  },
+  "Birmingham, Hodge Hill": {
+    "ppc": "LiamByrneMP",
+    "clp": [
+      "HodgeHillLabour"
+    ]
+  },
+  "West Worcestershire": {
+    "clp": [
+      "WestWorcsLab"
+    ]
+  },
+  "Barnsley Central": {
+    "ppc": "DanJarvisMP",
+    "clp": [
+      "BarnsleyCLP"
+    ]
+  },
+  "Rother Valley": {
+    "ppc": "Soph__wilson",
+    "clp": [
+      "RotherValleyCLP"
+    ]
+  },
+  "Tatton": {
+    "clp": [
+      "TattonCLP"
+    ]
+  },
+  "East Lothian": {
+    "ppc": "MartWhitfieldMP",
+    "clp": [
+      "EastLothianCLP"
+    ]
+  },
+  "Glasgow North": {
+    "ppc": "GlasgowPam",
+    "clp": [
+      "MSLabour"
+    ]
+  },
+  "South West Wiltshire": {
+    "ppc": "sandraporter_2",
+    "clp": [
+      "labour_south"
+    ]
+  },
+  "Kenilworth and Southam": {
+    "clp": [
+      "LabourKandS"
+    ]
+  },
+  "Meriden": {
+    "clp": [
+      "Solihull_Labour"
+    ]
+  },
+  "South Dorset": {
+    "ppc": "CarralynParkes",
+    "clp": [
+      "SDorsetLabour"
+    ]
+  },
+  "Glasgow North East": {
+    "clp": []
+  },
+  "Skipton and Ripon": {
+    "ppc": "Brian_A_McDaid",
+    "clp": [
+      "SkiptonRiponCLP"
+    ]
+  },
+  "Worsley and Eccles South": {
+    "ppc": "KeeleyMP",
+    "clp": [
+      "WandES_CLP"
+    ]
+  },
+  "Jarrow": {
+    "clp": []
+  },
+  "Taunton Deane": {
+    "ppc": "LiamCanhamTD",
+    "clp": [
+      "labourtaunton"
+    ]
+  },
+  "Coventry North West": {
+    "ppc": "TaiwoOwatemi",
+    "clp": [
+      "CovNWestCLP"
+    ]
+  },
+  "Paisley and Renfrewshire North": {
+    "ppc": "Alison_S_Taylor",
+    "clp": []
+  },
+  "Gainsborough": {
+    "clp": [
+      "GainsboroughLab"
+    ]
+  },
+  "Caithness, Sutherland and Easter Ross": {
+    "clp": []
+  },
+  "Na h-Eileanan an Iar": {
+    "ppc": "AKMacCorquodale",
+    "clp": []
+  },
+  "Macclesfield": {
+    "ppc": "Puttick4Macc",
+    "clp": [
+      "Puttick4Macc",
+      "SteveCarter001"
+    ]
+  },
+  "Liverpool, Riverside": {
+    "clp": [
+      "RivLabLeft"
+    ]
+  },
+  "South Suffolk": {
+    "clp": [
+      "SouthSuffolkLab",
+      "labsouthsuffolk"
+    ]
+  },
+  "Erith and Thamesmead": {
+    "ppc": "abenaopp",
+    "clp": [
+      "E_TLabour"
+    ]
+  },
+  "South Ribble": {
+    "ppc": "KimSnape",
+    "clp": [
+      "SRLabour"
+    ]
+  },
+  "Reading West": {
+    "ppc": "RachelEden",
+    "clp": [
+      "ReadingLabour"
+    ]
+  },
+  "Torridge and West Devon": {
+    "ppc": "bullet_siobhan",
+    "clp": [
+      "WESTDEVONLABOUR"
+    ]
+  },
+  "Nottingham South": {
+    "ppc": "LilianGreenwood",
+    "clp": [
+      "ng_labour"
+    ]
+  },
+  "West Dorset": {
+    "ppc": "jasonoutthere",
+    "clp": [
+      "WDorsetLabour"
+    ]
+  },
+  "Poole": {
+    "ppc": "SCAitkenhead",
+    "clp": [
+      "Poole_Labour",
+      "PooleLabour"
+    ]
+  },
+  "Bournemouth West": {
+    "ppc": "dave4bmthwest",
+    "clp": [
+      "BournemouthLP"
+    ]
+  },
+  "Canterbury": {
+    "ppc": "RosieDuffield1",
+    "clp": [
+      "CantLabour"
+    ]
+  },
+  "Westminster North": {
+    "ppc": "KarenPBuckMP",
+    "clp": [
+      "wminsterlabour"
+    ]
+  },
+  "North West Leicestershire": {
+    "ppc": "terrieynon",
+    "clp": []
+  },
+  "South West Devon": {
+    "ppc": "MsAlexBev",
+    "clp": [
+      "SWD_Labour"
+    ]
+  },
+  "North West Norfolk": {
+    "ppc": "JoRust45",
+    "clp": [
+      "NWNCLP"
+    ]
+  },
+  "St Albans": {
+    "ppc": "rebeccalury",
+    "clp": [
+      "StAlbansLabour"
+    ]
+  },
+  "Aldridge-Brownhills": {
+    "clp": [
+      "AlBrownhillsCLP"
+    ]
+  },
+  "Montgomeryshire": {
+    "ppc": "kaitduerden",
+    "clp": [
+      "MontyLabour"
+    ]
+  },
+  "Preston": {
+    "ppc": "votehendrick",
+    "clp": [
+      "prestonlabour"
+    ]
+  },
+  "Brent North": {
+    "clp": [
+      "BrentN_Labour"
+    ]
+  },
+  "North Tyneside": {
+    "clp": [
+      "NTynesideLab"
+    ]
+  },
+  "North East Hampshire": {
+    "clp": []
+  },
+  "East Surrey": {
+    "clp": [
+      "ESurreyLabour"
+    ]
+  },
+  "Birmingham, Northfield": {
+    "ppc": "RichardBurdenMP",
+    "clp": [
+      "NorthfieldCLP"
+    ]
+  },
+  "Penrith and The Border": {
+    "clp": [
+      "PenrithLabour"
+    ]
+  },
+  "Romford": {
+    "ppc": "GigiMaltese",
+    "clp": [
+      "romfordlabour"
+    ]
+  },
+  "Salford and Eccles": {
+    "ppc": "RLong_Bailey",
+    "clp": []
+  },
+  "Wolverhampton South East": {
+    "ppc": "patmcfaddenmp",
+    "clp": [
+      "WolvesSELabour"
+    ]
+  },
+  "Bethnal Green and Bow": {
+    "ppc": "rushanaraali",
+    "clp": [
+      "bgblabour"
+    ]
+  },
+  "Delyn": {
+    "ppc": "DavidHansonMP",
+    "clp": [
+      "DelynLabour"
+    ]
+  },
+  "Fareham": {
+    "clp": [
+      "FarehamLabour"
+    ]
+  },
+  "Central Ayrshire": {
+    "ppc": "loucoll",
+    "clp": []
+  },
+  "Henley": {
+    "clp": []
+  },
+  "Argyll and Bute": {
+    "clp": []
+  },
+  "Isle of Wight": {
+    "clp": [
+      "Island_Labour"
+    ]
+  },
+  "Barnsley East": {
+    "ppc": "Steph_Peacock",
+    "clp": [
+      "BarnsleyEastCLP"
+    ]
+  },
+  "Belfast East": {
+    "clp": [
+      "LabourBelfast"
+    ]
+  },
+  "Gillingham and Rainham": {
+    "clp": [
+      "GRLabour"
+    ]
+  },
+  "Islwyn": {
+    "ppc": "VoteChrisEvans",
+    "clp": [
+      "IslwynLabour"
+    ]
+  },
+  "Bristol South": {
+    "ppc": "karinsmyth",
+    "clp": [
+      "BristolSouthLab"
+    ]
+  },
+  "Dulwich and West Norwood": {
+    "ppc": "helenhayes_",
+    "clp": [
+      "DaWNLabour"
+    ]
+  },
+  "Lichfield": {
+    "clp": [
+      "LichfieldLabour",
+      "labour4lichf"
+    ]
+  },
+  "Burnley": {
+    "clp": [
+      "BurnleyLabour"
+    ]
+  },
+  "Wells": {
+    "clp": [
+      "LabourWells"
+    ]
+  },
+  "West Aberdeenshire and Kincardine": {
+    "ppc": "PaddyCoffield",
+    "clp": []
+  },
+  "Cheadle": {
+    "ppc": "ChauhanZahid",
+    "clp": [
+      "cheadlelabour"
+    ]
+  },
+  "South West Hertfordshire": {
+    "clp": []
+  },
+  "Glasgow East": {
+    "ppc": "Katewatson67",
+    "clp": []
+  },
+  "Leicester West": {
+    "ppc": "leicesterliz",
+    "clp": [
+      "LestahWestCLP"
+    ]
+  },
+  "Wellingborough": {
+    "ppc": "Andrea_Labour",
+    "clp": [
+      "WellRushLabour"
+    ]
+  },
+  "Gosport": {
+    "clp": [
+      "GosportLabour1"
+    ]
+  },
+  "Birmingham, Edgbaston": {
+    "ppc": "PreetKGillMP",
+    "clp": [
+      "edgbastonCLP"
+    ]
+  },
+  "Birkenhead": {
+    "ppc": "GrassrootsMick1",
+    "clp": [
+      "BirkoLabour"
+    ]
+  },
+  "Poplar and Limehouse": {
+    "ppc": "ApsanaForPL",
+    "clp": [
+      "LabourPandL"
+    ]
+  },
+  "Carmarthen East and Dinefwr": {
+    "ppc": "Maria4CarmsEast",
+    "clp": [
+      "CEandDLabour"
+    ]
+  },
+  "Enfield North": {
+    "ppc": "FeryalClark",
+    "clp": [
+      "EnfieldNorthCLP"
+    ]
+  },
+  "South Norfolk": {
+    "clp": [
+      "southnorfolk"
+    ]
+  },
+  "Dover": {
+    "ppc": "Charlotte4Dover",
+    "clp": [
+      "dover_labour"
+    ]
+  },
+  "Derbyshire Dales": {
+    "clp": [
+      "DDLabour"
+    ]
+  },
+  "Battersea": {
+    "ppc": "MarshadeCordova",
+    "clp": [
+      "BatterseaLabour"
+    ]
+  },
+  "Harrow East": {
+    "ppc": "pam4harroweast",
+    "clp": [
+      "harrowelabour"
+    ]
+  },
+  "Sutton and Cheam": {
+    "clp": [
+      "SuttonCheamCLP"
+    ]
+  },
+  "West Bromwich East": {
+    "clp": [
+      "WBE_Labour"
+    ]
+  },
+  "Norwich North": {
+    "ppc": "LabKarenDavis",
+    "clp": [
+      "NorwichLabour"
+    ]
+  },
+  "Dumfries and Galloway": {
+    "clp": [
+      "DGLabour"
+    ]
+  },
+  "Coatbridge, Chryston and Bellshill": {
+    "ppc": "hgaffney48",
+    "clp": []
+  },
+  "Eastleigh": {
+    "ppc": "Sam4Eastleigh",
+    "clp": [
+      "EastleighLab"
+    ]
+  },
+  "Worcester": {
+    "ppc": "LynnDenham1",
+    "clp": [
+      "WorcesterLabour"
+    ]
+  },
+  "Ilford South": {
+    "ppc": "SamTarry",
+    "clp": [
+      "IlfordSouthCLP"
+    ]
+  },
+  "Saffron Walden": {
+    "clp": [
+      "SWLabour"
+    ]
+  },
+  "City of Chester": {
+    "ppc": "ChrisM4Chester",
+    "clp": []
+  },
+  "North East Somerset": {
+    "ppc": "MarkHubandNES",
+    "clp": [
+      "NESLabour"
+    ]
+  }
+}

--- a/server/location/testdata/readme
+++ b/server/location/testdata/readme
@@ -1,0 +1,1 @@
+// This folder's contents should be stored in /data , but are here for ease of portability while we are developing the ting.


### PR DESCRIPTION
Adds meaningful postcode lookup (from postcodes.io) via static route /locationtest (for testing) and main route /api.
Currently, postcode data must be passed in explicity, eg with /api?pc="SW1A0AA" and does not persist across express session.
Location objects are created (and one returned in response), which will be
* empty and default to location.specifity = 0 ; defaultTwitterFollow = '@uklabour'
* or populated with, minimally, canonicalised location data eg postcode and locatoin.specificity.
Maximum location.specificity is 10, signifying full postcode or 4d.p. latLng.
latLng are compatible with leaflet.js


